### PR TITLE
feat: allow to infer columns in table when schema not found

### DIFF
--- a/datalineage/node.py
+++ b/datalineage/node.py
@@ -21,8 +21,8 @@ class NodeType(str, Enum):
 class Node:
     name: Union[str, exp.Expression]
     expression: exp.Expression
-    generated_expression: exp.Expression
-    source_expression: exp.Expression
+    generated_expression: Optional[exp.Expression]
+    source_expression: Optional[exp.Expression]
     _parent: Optional["Node"] = None
     node_type: Optional[NodeType] = None
     children: List["Node"] = field(default_factory=list)
@@ -53,6 +53,17 @@ class Node:
             child.parent = self
             self.children.append(child)
         return self
+
+    def get_child_by_name(self, child_name: str) -> Optional["Node"]:
+        """Get a child of this node, return None if not found."""
+        resolved_child = None
+
+        for child in self.children:
+            if child_name == child.name:
+                resolved_child = child
+                break
+
+        return resolved_child
 
     def walk(self):
         """Pre-Order DFS"""


### PR DESCRIPTION
Example query:

```sql
select id, name, phone, address from catalog.schema1.customer2
where name like 'cus%'
```

When we do not supply a schema for the table, datalineage should infer these columns id, name, phone, and address are part of the table. Then we can link the column to its downstream.

```mermaid
%%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%
graph LR
subgraph 2464097070896 ["NodeType.TABLE: catalog.schema1.customer2 AS customer2"]
2464097071328["id"]
2464097071808["name"]
2464097071904["phone"]
2464097072000["address"]
end

subgraph 2464071044656 ["NodeType.SELECT: _output_"]
2464097068928["id"]
2464097071616["name"]
2464097071856["phone"]
2464097071952["address"]
end
2464097071328 --> 2464097068928
2464097071808 --> 2464097071616
2464097071904 --> 2464097071856
2464097072000 --> 2464097071952
```

How to test this feature: manual.

 