### PR TITLE
feat: support select statement without from

### DIFF
--- a/tests/lineage/lineage_conf.yaml
+++ b/tests/lineage/lineage_conf.yaml
@@ -16,3 +16,15 @@
   schema_path: schema.json
   dialect:
   output_type: json
+- path: test_cases/test_select_not_from_table
+  input_path: 00_input.sql
+  output_path: 00_json_output.json
+  schema_path: schema.json
+  dialect:
+  output_type: json
+- path: test_cases/test_select_not_from_table
+  input_path: 01_input.sql
+  output_path: 01_json_output.json
+  schema_path: schema.json
+  dialect:
+  output_type: json

--- a/tests/lineage/test_cases/test_select_not_from_table/00_input.sql
+++ b/tests/lineage/test_cases/test_select_not_from_table/00_input.sql
@@ -1,0 +1,12 @@
+with cte1 as (
+    select id, name, phone, address from catalog.schema1.customer
+    where name like 'join%'
+)
+, cte2 as (
+    select -1 as my_id, 'dummy' as name, 1234 phone, 'unknown' address
+)
+select * from cte1
+union all
+select -2 as my_id, 'dummy 2' as name, 12345 phone, 'unknown2' address
+union all
+select * from cte2

--- a/tests/lineage/test_cases/test_select_not_from_table/00_json_output.json
+++ b/tests/lineage/test_cases/test_select_not_from_table/00_json_output.json
@@ -1,0 +1,737 @@
+{
+    "name": "myroot",
+    "expression": "ANCHOR",
+    "generated_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\" UNION ALL WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT -2 AS \"my_id\", 'dummy 2' AS \"name\", 12345 AS \"phone\", 'unknown2' AS \"address\" UNION ALL WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+    "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\" UNION ALL WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT -2 AS \"my_id\", 'dummy 2' AS \"name\", 12345 AS \"phone\", 'unknown2' AS \"address\" UNION ALL WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+    "node_type": "Select",
+    "children": [],
+    "downstreams": [
+        {
+            "name": "Union",
+            "expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\" UNION ALL WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT -2 AS \"my_id\", 'dummy 2' AS \"name\", 12345 AS \"phone\", 'unknown2' AS \"address\" UNION ALL WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+            "generated_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\" UNION ALL WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT -2 AS \"my_id\", 'dummy 2' AS \"name\", 12345 AS \"phone\", 'unknown2' AS \"address\" UNION ALL WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\" UNION ALL WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT -2 AS \"my_id\", 'dummy 2' AS \"name\", 12345 AS \"phone\", 'unknown2' AS \"address\" UNION ALL WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+            "node_type": "Union",
+            "children": [
+                {
+                    "name": "id",
+                    "expression": "id",
+                    "generated_expression": "id",
+                    "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\" UNION ALL WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT -2 AS \"my_id\", 'dummy 2' AS \"name\", 12345 AS \"phone\", 'unknown2' AS \"address\"",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "id",
+                            "expression": "\"cte1\".\"id\"",
+                            "generated_expression": "\"cte1\".\"id\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "id",
+                                    "expression": "\"customer\".\"id\"",
+                                    "generated_expression": "\"customer\".\"id\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "id",
+                                            "expression": "id",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "my_id",
+                            "expression": "-2",
+                            "generated_expression": "-2",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT -2 AS \"my_id\", 'dummy 2' AS \"name\", 12345 AS \"phone\", 'unknown2' AS \"address\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": []
+                        },
+                        {
+                            "name": "my_id",
+                            "expression": "\"cte2\".\"my_id\"",
+                            "generated_expression": "\"cte2\".\"my_id\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "my_id",
+                                    "expression": "-1",
+                                    "generated_expression": "-1",
+                                    "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "name",
+                    "expression": "name",
+                    "generated_expression": "name",
+                    "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\" UNION ALL WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT -2 AS \"my_id\", 'dummy 2' AS \"name\", 12345 AS \"phone\", 'unknown2' AS \"address\"",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "name",
+                            "expression": "\"cte1\".\"name\"",
+                            "generated_expression": "\"cte1\".\"name\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "name",
+                                    "expression": "\"customer\".\"name\"",
+                                    "generated_expression": "\"customer\".\"name\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "name",
+                                            "expression": "name",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "name",
+                            "expression": "'dummy 2'",
+                            "generated_expression": "'dummy 2'",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT -2 AS \"my_id\", 'dummy 2' AS \"name\", 12345 AS \"phone\", 'unknown2' AS \"address\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": []
+                        },
+                        {
+                            "name": "name",
+                            "expression": "\"cte2\".\"name\"",
+                            "generated_expression": "\"cte2\".\"name\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "name",
+                                    "expression": "'dummy'",
+                                    "generated_expression": "'dummy'",
+                                    "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "phone",
+                    "expression": "phone",
+                    "generated_expression": "phone",
+                    "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\" UNION ALL WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT -2 AS \"my_id\", 'dummy 2' AS \"name\", 12345 AS \"phone\", 'unknown2' AS \"address\"",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "phone",
+                            "expression": "\"cte1\".\"phone\"",
+                            "generated_expression": "\"cte1\".\"phone\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "phone",
+                                    "expression": "\"customer\".\"phone\"",
+                                    "generated_expression": "\"customer\".\"phone\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "phone",
+                                            "expression": "phone",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "phone",
+                            "expression": "12345",
+                            "generated_expression": "12345",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT -2 AS \"my_id\", 'dummy 2' AS \"name\", 12345 AS \"phone\", 'unknown2' AS \"address\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": []
+                        },
+                        {
+                            "name": "phone",
+                            "expression": "\"cte2\".\"phone\"",
+                            "generated_expression": "\"cte2\".\"phone\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "phone",
+                                    "expression": "1234",
+                                    "generated_expression": "1234",
+                                    "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "address",
+                    "expression": "address",
+                    "generated_expression": "address",
+                    "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\" UNION ALL WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT -2 AS \"my_id\", 'dummy 2' AS \"name\", 12345 AS \"phone\", 'unknown2' AS \"address\"",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "address",
+                            "expression": "\"cte1\".\"address\"",
+                            "generated_expression": "\"cte1\".\"address\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "address",
+                                    "expression": "\"customer\".\"address\"",
+                                    "generated_expression": "\"customer\".\"address\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "address",
+                                            "expression": "address",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "address",
+                            "expression": "'unknown2'",
+                            "generated_expression": "'unknown2'",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT -2 AS \"my_id\", 'dummy 2' AS \"name\", 12345 AS \"phone\", 'unknown2' AS \"address\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": []
+                        },
+                        {
+                            "name": "address",
+                            "expression": "\"cte2\".\"address\"",
+                            "generated_expression": "\"cte2\".\"address\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "address",
+                                    "expression": "'unknown'",
+                                    "generated_expression": "'unknown'",
+                                    "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "downstreams": [
+                {
+                    "name": "Union Slot#0",
+                    "expression": "\"cte1\" AS \"cte1\"",
+                    "generated_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\"",
+                    "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\"",
+                    "node_type": "Select",
+                    "children": [
+                        {
+                            "name": "id",
+                            "expression": "\"cte1\".\"id\"",
+                            "generated_expression": "\"cte1\".\"id\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "id",
+                                    "expression": "\"customer\".\"id\"",
+                                    "generated_expression": "\"customer\".\"id\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "id",
+                                            "expression": "id",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "name",
+                            "expression": "\"cte1\".\"name\"",
+                            "generated_expression": "\"cte1\".\"name\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "name",
+                                    "expression": "\"customer\".\"name\"",
+                                    "generated_expression": "\"customer\".\"name\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "name",
+                                            "expression": "name",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "phone",
+                            "expression": "\"cte1\".\"phone\"",
+                            "generated_expression": "\"cte1\".\"phone\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "phone",
+                                    "expression": "\"customer\".\"phone\"",
+                                    "generated_expression": "\"customer\".\"phone\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "phone",
+                                            "expression": "phone",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "address",
+                            "expression": "\"cte1\".\"address\"",
+                            "generated_expression": "\"cte1\".\"address\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "address",
+                                    "expression": "\"customer\".\"address\"",
+                                    "generated_expression": "\"customer\".\"address\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "address",
+                                            "expression": "address",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "downstreams": [
+                        {
+                            "name": "\"cte1\" AS \"cte1\"",
+                            "expression": "\"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                            "generated_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                            "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                            "node_type": "CTE",
+                            "children": [
+                                {
+                                    "name": "id",
+                                    "expression": "\"customer\".\"id\"",
+                                    "generated_expression": "\"customer\".\"id\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "id",
+                                            "expression": "id",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "name",
+                                    "expression": "\"customer\".\"name\"",
+                                    "generated_expression": "\"customer\".\"name\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "name",
+                                            "expression": "name",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "phone",
+                                    "expression": "\"customer\".\"phone\"",
+                                    "generated_expression": "\"customer\".\"phone\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "phone",
+                                            "expression": "phone",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "address",
+                                    "expression": "\"customer\".\"address\"",
+                                    "generated_expression": "\"customer\".\"address\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "address",
+                                            "expression": "address",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ],
+                            "downstreams": [
+                                {
+                                    "name": "\"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                    "expression": "\"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                    "generated_expression": null,
+                                    "source_expression": null,
+                                    "node_type": "Table",
+                                    "children": [
+                                        {
+                                            "name": "id",
+                                            "expression": "id",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        },
+                                        {
+                                            "name": "name",
+                                            "expression": "name",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        },
+                                        {
+                                            "name": "phone",
+                                            "expression": "phone",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        },
+                                        {
+                                            "name": "address",
+                                            "expression": "address",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        },
+                                        {
+                                            "name": "location",
+                                            "expression": "location",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ],
+                                    "downstreams": []
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "Union Slot#1",
+                    "expression": "'empty node'",
+                    "generated_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT -2 AS \"my_id\", 'dummy 2' AS \"name\", 12345 AS \"phone\", 'unknown2' AS \"address\"",
+                    "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT -2 AS \"my_id\", 'dummy 2' AS \"name\", 12345 AS \"phone\", 'unknown2' AS \"address\"",
+                    "node_type": "Select",
+                    "children": [
+                        {
+                            "name": "my_id",
+                            "expression": "-2",
+                            "generated_expression": "-2",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT -2 AS \"my_id\", 'dummy 2' AS \"name\", 12345 AS \"phone\", 'unknown2' AS \"address\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": []
+                        },
+                        {
+                            "name": "name",
+                            "expression": "'dummy 2'",
+                            "generated_expression": "'dummy 2'",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT -2 AS \"my_id\", 'dummy 2' AS \"name\", 12345 AS \"phone\", 'unknown2' AS \"address\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": []
+                        },
+                        {
+                            "name": "phone",
+                            "expression": "12345",
+                            "generated_expression": "12345",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT -2 AS \"my_id\", 'dummy 2' AS \"name\", 12345 AS \"phone\", 'unknown2' AS \"address\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": []
+                        },
+                        {
+                            "name": "address",
+                            "expression": "'unknown2'",
+                            "generated_expression": "'unknown2'",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT -2 AS \"my_id\", 'dummy 2' AS \"name\", 12345 AS \"phone\", 'unknown2' AS \"address\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": []
+                        }
+                    ],
+                    "downstreams": []
+                },
+                {
+                    "name": "Union Slot#2",
+                    "expression": "\"cte2\" AS \"cte2\"",
+                    "generated_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+                    "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+                    "node_type": "Select",
+                    "children": [
+                        {
+                            "name": "my_id",
+                            "expression": "\"cte2\".\"my_id\"",
+                            "generated_expression": "\"cte2\".\"my_id\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "my_id",
+                                    "expression": "-1",
+                                    "generated_expression": "-1",
+                                    "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ]
+                        },
+                        {
+                            "name": "name",
+                            "expression": "\"cte2\".\"name\"",
+                            "generated_expression": "\"cte2\".\"name\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "name",
+                                    "expression": "'dummy'",
+                                    "generated_expression": "'dummy'",
+                                    "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ]
+                        },
+                        {
+                            "name": "phone",
+                            "expression": "\"cte2\".\"phone\"",
+                            "generated_expression": "\"cte2\".\"phone\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "phone",
+                                    "expression": "1234",
+                                    "generated_expression": "1234",
+                                    "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ]
+                        },
+                        {
+                            "name": "address",
+                            "expression": "\"cte2\".\"address\"",
+                            "generated_expression": "\"cte2\".\"address\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "address",
+                                    "expression": "'unknown'",
+                                    "generated_expression": "'unknown'",
+                                    "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ]
+                        }
+                    ],
+                    "downstreams": [
+                        {
+                            "name": "\"cte2\" AS \"cte2\"",
+                            "expression": "'empty node'",
+                            "generated_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                            "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                            "node_type": "CTE",
+                            "children": [
+                                {
+                                    "name": "my_id",
+                                    "expression": "-1",
+                                    "generated_expression": "-1",
+                                    "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                },
+                                {
+                                    "name": "name",
+                                    "expression": "'dummy'",
+                                    "generated_expression": "'dummy'",
+                                    "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                },
+                                {
+                                    "name": "phone",
+                                    "expression": "1234",
+                                    "generated_expression": "1234",
+                                    "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                },
+                                {
+                                    "name": "address",
+                                    "expression": "'unknown'",
+                                    "generated_expression": "'unknown'",
+                                    "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ],
+                            "downstreams": []
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/lineage/test_cases/test_select_not_from_table/01_input.sql
+++ b/tests/lineage/test_cases/test_select_not_from_table/01_input.sql
@@ -1,0 +1,12 @@
+with cte1 as (
+    select id, name, phone, address from catalog.schema1.customer
+    where name like 'join%'
+)
+, cte2 as (
+    select d.* from (
+        select -1 as my_id, 'dummy' as name, 1234 phone, 'unknown' address
+    ) d
+)
+select * from cte1
+union all
+select * from cte2

--- a/tests/lineage/test_cases/test_select_not_from_table/01_json_output.json
+++ b/tests/lineage/test_cases/test_select_not_from_table/01_json_output.json
@@ -1,0 +1,822 @@
+{
+    "name": "myroot",
+    "expression": "ANCHOR",
+    "generated_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\" UNION ALL WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+    "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\" UNION ALL WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+    "node_type": "Select",
+    "children": [],
+    "downstreams": [
+        {
+            "name": "Union",
+            "expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\" UNION ALL WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+            "generated_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\" UNION ALL WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\" UNION ALL WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+            "node_type": "Union",
+            "children": [
+                {
+                    "name": "id",
+                    "expression": "id",
+                    "generated_expression": "id",
+                    "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\" UNION ALL WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "id",
+                            "expression": "\"cte1\".\"id\"",
+                            "generated_expression": "\"cte1\".\"id\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "id",
+                                    "expression": "\"customer\".\"id\"",
+                                    "generated_expression": "\"customer\".\"id\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "id",
+                                            "expression": "id",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "my_id",
+                            "expression": "\"cte2\".\"my_id\"",
+                            "generated_expression": "\"cte2\".\"my_id\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "my_id",
+                                    "expression": "\"d\".\"my_id\"",
+                                    "generated_expression": "\"d\".\"my_id\"",
+                                    "source_expression": "SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "my_id",
+                                            "expression": "-1",
+                                            "generated_expression": "-1",
+                                            "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "name",
+                    "expression": "name",
+                    "generated_expression": "name",
+                    "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\" UNION ALL WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "name",
+                            "expression": "\"cte1\".\"name\"",
+                            "generated_expression": "\"cte1\".\"name\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "name",
+                                    "expression": "\"customer\".\"name\"",
+                                    "generated_expression": "\"customer\".\"name\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "name",
+                                            "expression": "name",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "name",
+                            "expression": "\"cte2\".\"name\"",
+                            "generated_expression": "\"cte2\".\"name\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "name",
+                                    "expression": "\"d\".\"name\"",
+                                    "generated_expression": "\"d\".\"name\"",
+                                    "source_expression": "SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "name",
+                                            "expression": "'dummy'",
+                                            "generated_expression": "'dummy'",
+                                            "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "phone",
+                    "expression": "phone",
+                    "generated_expression": "phone",
+                    "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\" UNION ALL WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "phone",
+                            "expression": "\"cte1\".\"phone\"",
+                            "generated_expression": "\"cte1\".\"phone\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "phone",
+                                    "expression": "\"customer\".\"phone\"",
+                                    "generated_expression": "\"customer\".\"phone\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "phone",
+                                            "expression": "phone",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "phone",
+                            "expression": "\"cte2\".\"phone\"",
+                            "generated_expression": "\"cte2\".\"phone\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "phone",
+                                    "expression": "\"d\".\"phone\"",
+                                    "generated_expression": "\"d\".\"phone\"",
+                                    "source_expression": "SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "phone",
+                                            "expression": "1234",
+                                            "generated_expression": "1234",
+                                            "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "address",
+                    "expression": "address",
+                    "generated_expression": "address",
+                    "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\" UNION ALL WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "address",
+                            "expression": "\"cte1\".\"address\"",
+                            "generated_expression": "\"cte1\".\"address\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "address",
+                                    "expression": "\"customer\".\"address\"",
+                                    "generated_expression": "\"customer\".\"address\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "address",
+                                            "expression": "address",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "address",
+                            "expression": "\"cte2\".\"address\"",
+                            "generated_expression": "\"cte2\".\"address\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "address",
+                                    "expression": "\"d\".\"address\"",
+                                    "generated_expression": "\"d\".\"address\"",
+                                    "source_expression": "SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "address",
+                                            "expression": "'unknown'",
+                                            "generated_expression": "'unknown'",
+                                            "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "downstreams": [
+                {
+                    "name": "Union Slot#0",
+                    "expression": "\"cte1\" AS \"cte1\"",
+                    "generated_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\"",
+                    "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\"",
+                    "node_type": "Select",
+                    "children": [
+                        {
+                            "name": "id",
+                            "expression": "\"cte1\".\"id\"",
+                            "generated_expression": "\"cte1\".\"id\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "id",
+                                    "expression": "\"customer\".\"id\"",
+                                    "generated_expression": "\"customer\".\"id\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "id",
+                                            "expression": "id",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "name",
+                            "expression": "\"cte1\".\"name\"",
+                            "generated_expression": "\"cte1\".\"name\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "name",
+                                    "expression": "\"customer\".\"name\"",
+                                    "generated_expression": "\"customer\".\"name\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "name",
+                                            "expression": "name",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "phone",
+                            "expression": "\"cte1\".\"phone\"",
+                            "generated_expression": "\"cte1\".\"phone\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "phone",
+                                    "expression": "\"customer\".\"phone\"",
+                                    "generated_expression": "\"customer\".\"phone\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "phone",
+                                            "expression": "phone",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "address",
+                            "expression": "\"cte1\".\"address\"",
+                            "generated_expression": "\"cte1\".\"address\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte1\".\"id\" AS \"id\", \"cte1\".\"name\" AS \"name\", \"cte1\".\"phone\" AS \"phone\", \"cte1\".\"address\" AS \"address\" FROM \"cte1\" AS \"cte1\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "address",
+                                    "expression": "\"customer\".\"address\"",
+                                    "generated_expression": "\"customer\".\"address\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "address",
+                                            "expression": "address",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "downstreams": [
+                        {
+                            "name": "\"cte1\" AS \"cte1\"",
+                            "expression": "\"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                            "generated_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                            "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                            "node_type": "CTE",
+                            "children": [
+                                {
+                                    "name": "id",
+                                    "expression": "\"customer\".\"id\"",
+                                    "generated_expression": "\"customer\".\"id\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "id",
+                                            "expression": "id",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "name",
+                                    "expression": "\"customer\".\"name\"",
+                                    "generated_expression": "\"customer\".\"name\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "name",
+                                            "expression": "name",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "phone",
+                                    "expression": "\"customer\".\"phone\"",
+                                    "generated_expression": "\"customer\".\"phone\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "phone",
+                                            "expression": "phone",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "address",
+                                    "expression": "\"customer\".\"address\"",
+                                    "generated_expression": "\"customer\".\"address\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "address",
+                                            "expression": "address",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ],
+                            "downstreams": [
+                                {
+                                    "name": "\"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                    "expression": "\"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                    "generated_expression": null,
+                                    "source_expression": null,
+                                    "node_type": "Table",
+                                    "children": [
+                                        {
+                                            "name": "id",
+                                            "expression": "id",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        },
+                                        {
+                                            "name": "name",
+                                            "expression": "name",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        },
+                                        {
+                                            "name": "phone",
+                                            "expression": "phone",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        },
+                                        {
+                                            "name": "address",
+                                            "expression": "address",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        },
+                                        {
+                                            "name": "location",
+                                            "expression": "location",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ],
+                                    "downstreams": []
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "Union Slot#1",
+                    "expression": "\"cte2\" AS \"cte2\"",
+                    "generated_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+                    "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+                    "node_type": "Select",
+                    "children": [
+                        {
+                            "name": "my_id",
+                            "expression": "\"cte2\".\"my_id\"",
+                            "generated_expression": "\"cte2\".\"my_id\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "my_id",
+                                    "expression": "\"d\".\"my_id\"",
+                                    "generated_expression": "\"d\".\"my_id\"",
+                                    "source_expression": "SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "my_id",
+                                            "expression": "-1",
+                                            "generated_expression": "-1",
+                                            "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "name",
+                            "expression": "\"cte2\".\"name\"",
+                            "generated_expression": "\"cte2\".\"name\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "name",
+                                    "expression": "\"d\".\"name\"",
+                                    "generated_expression": "\"d\".\"name\"",
+                                    "source_expression": "SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "name",
+                                            "expression": "'dummy'",
+                                            "generated_expression": "'dummy'",
+                                            "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "phone",
+                            "expression": "\"cte2\".\"phone\"",
+                            "generated_expression": "\"cte2\".\"phone\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "phone",
+                                    "expression": "\"d\".\"phone\"",
+                                    "generated_expression": "\"d\".\"phone\"",
+                                    "source_expression": "SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "phone",
+                                            "expression": "1234",
+                                            "generated_expression": "1234",
+                                            "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "address",
+                            "expression": "\"cte2\".\"address\"",
+                            "generated_expression": "\"cte2\".\"address\"",
+                            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'join%'), \"cte2\" AS (SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\") SELECT \"cte2\".\"my_id\" AS \"my_id\", \"cte2\".\"name\" AS \"name\", \"cte2\".\"phone\" AS \"phone\", \"cte2\".\"address\" AS \"address\" FROM \"cte2\" AS \"cte2\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "address",
+                                    "expression": "\"d\".\"address\"",
+                                    "generated_expression": "\"d\".\"address\"",
+                                    "source_expression": "SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "address",
+                                            "expression": "'unknown'",
+                                            "generated_expression": "'unknown'",
+                                            "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "downstreams": [
+                        {
+                            "name": "\"cte2\" AS \"cte2\"",
+                            "expression": "(SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\"",
+                            "generated_expression": "SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\"",
+                            "source_expression": "SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\"",
+                            "node_type": "CTE",
+                            "children": [
+                                {
+                                    "name": "my_id",
+                                    "expression": "\"d\".\"my_id\"",
+                                    "generated_expression": "\"d\".\"my_id\"",
+                                    "source_expression": "SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "my_id",
+                                            "expression": "-1",
+                                            "generated_expression": "-1",
+                                            "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "name",
+                                    "expression": "\"d\".\"name\"",
+                                    "generated_expression": "\"d\".\"name\"",
+                                    "source_expression": "SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "name",
+                                            "expression": "'dummy'",
+                                            "generated_expression": "'dummy'",
+                                            "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "phone",
+                                    "expression": "\"d\".\"phone\"",
+                                    "generated_expression": "\"d\".\"phone\"",
+                                    "source_expression": "SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "phone",
+                                            "expression": "1234",
+                                            "generated_expression": "1234",
+                                            "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "address",
+                                    "expression": "\"d\".\"address\"",
+                                    "generated_expression": "\"d\".\"address\"",
+                                    "source_expression": "SELECT \"d\".\"my_id\" AS \"my_id\", \"d\".\"name\" AS \"name\", \"d\".\"phone\" AS \"phone\", \"d\".\"address\" AS \"address\" FROM (SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "address",
+                                            "expression": "'unknown'",
+                                            "generated_expression": "'unknown'",
+                                            "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ],
+                            "downstreams": [
+                                {
+                                    "name": "d",
+                                    "expression": "(SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\") AS \"d\"",
+                                    "generated_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                    "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                    "node_type": "Subquery",
+                                    "children": [
+                                        {
+                                            "name": "my_id",
+                                            "expression": "-1",
+                                            "generated_expression": "-1",
+                                            "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        },
+                                        {
+                                            "name": "name",
+                                            "expression": "'dummy'",
+                                            "generated_expression": "'dummy'",
+                                            "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        },
+                                        {
+                                            "name": "phone",
+                                            "expression": "1234",
+                                            "generated_expression": "1234",
+                                            "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        },
+                                        {
+                                            "name": "address",
+                                            "expression": "'unknown'",
+                                            "generated_expression": "'unknown'",
+                                            "source_expression": "SELECT -1 AS \"my_id\", 'dummy' AS \"name\", 1234 AS \"phone\", 'unknown' AS \"address\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ],
+                                    "downstreams": []
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/lineage/test_cases/test_select_not_from_table/schema.json
+++ b/tests/lineage/test_cases/test_select_not_from_table/schema.json
@@ -1,0 +1,29 @@
+{
+  "catalog": {
+      "schema1": {
+          "customer": {
+              "id": "INTEGER",
+              "name": "STRING",
+              "phone": "STRING",
+              "address": "STRING",
+              "location": "STRING"
+          },
+          "user_demographics": {
+              "id": "INTEGER",
+              "name": "STRING",
+              "age": "STRING",
+              "phone": "STRING",
+              "customer_job": "STRING",
+              "parent": "STRING"
+          },
+          "tbl_cte3": {
+              "id": "INTEGER",
+              "name": "STRING",
+              "age": "STRING",
+              "phone": "STRING",
+              "address": "STRING",
+              "job": "STRING"
+          }
+      }
+  }
+}


### PR DESCRIPTION
Bug fixes when lineage query contains select statement without from keyword, a.k.a not select from table.

Input: 
```sql
with cte1 as (
    select id, name, phone, address from catalog.schema1.customer
    where name like 'join%'
)
, cte2 as (
    select d.* from (
        select -1 as my_id, 'dummy' as name, 1234 phone, 'unknown' address
    ) d
)
select * from cte1
union all
select * from cte2
```

Output: 

```mermaid
%%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%
graph LR
subgraph 127828008890912 ["Table: catalog.schema1.customer AS customer"]
127828009287840["id"]
127828009287888["name"]
127828009287984["phone"]
127828009287792["address"]
127828009288080["location"]
end

subgraph 127828008894128 ["CTE: cte1 AS cte1"]
127828009287744["id"]
127828009288032["name"]
127828009288176["phone"]
127828009288128["address"]
end
127828009287840 --> 127828009287744
127828009287888 --> 127828009288032
127828009287984 --> 127828009288176
127828009287792 --> 127828009288128

subgraph 127828008893648 ["Select: Union Slot#0"]
127828009288224["id"]
127828009288272["name"]
127828009288464["phone"]
127828008893792["address"]
end
127828009287744 --> 127828009288224
127828009288032 --> 127828009288272
127828009288176 --> 127828009288464
127828009288128 --> 127828008893792

subgraph 127828009289040 ["Subquery: d"]
127828009289136["my_id"]
127828009288848["name"]
127828009288320["phone"]
127828009288992["address"]
end

subgraph 127828009288944 ["CTE: cte2 AS cte2"]
127828009289088["my_id"]
127828009288608["name"]
127828009289184["phone"]
127828009289328["address"]
end
127828009289136 --> 127828009289088
127828009288848 --> 127828009288608
127828009288320 --> 127828009289184
127828009288992 --> 127828009289328

subgraph 127828008893744 ["Select: Union Slot#1"]
127828009289424["my_id"]
127828009289280["name"]
127828009289664["phone"]
127828009289232["address"]
end
127828009289088 --> 127828009289424
127828009288608 --> 127828009289280
127828009289184 --> 127828009289664
127828009289328 --> 127828009289232

subgraph 127828008894176 ["Union: Union"]
127828008893984["id"]
127828008893936["name"]
127828008894224["phone"]
127828008893696["address"]
end
127828009288224 --> 127828008893984
127828009289424 --> 127828008893984
127828009288272 --> 127828008893936
127828009289280 --> 127828008893936
127828009288464 --> 127828008894224
127828009289664 --> 127828008894224
127828008893792 --> 127828008893696
127828009289232 --> 127828008893696
```

Another input:

```sql
with cte1 as (
    select id, name, phone, address from catalog.schema1.customer
    where name like 'join%'
)
, cte2 as (
    select -1 as my_id, 'dummy' as name, 1234 phone, 'unknown' address
)
select * from cte1
union all
select -2 as my_id, 'dummy 2' as name, 12345 phone, 'unknown2' address
union all
select * from cte2
```

Output:
```mermaid
%%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%
graph LR
subgraph 129760547946848 ["Table: catalog.schema1.customer AS customer"]
129760547946992["id"]
129760547946944["name"]
129760547947088["phone"]
129760547947040["address"]
129760547947184["location"]
end

subgraph 129760547946704 ["CTE: cte1 AS cte1"]
129760547946800["id"]
129760547947136["name"]
129760547947280["phone"]
129760547947232["address"]
end
129760547946992 --> 129760547946800
129760547946944 --> 129760547947136
129760547947088 --> 129760547947280
129760547947040 --> 129760547947232

subgraph 129760547946656 ["Select: Union Slot#0"]
129760547947328["id"]
129760547947376["name"]
129760547947856["phone"]
129760547536080["address"]
end
129760547946800 --> 129760547947328
129760547947136 --> 129760547947376
129760547947280 --> 129760547947856
129760547947232 --> 129760547536080

subgraph 129760547946896 ["Select: Union Slot#1"]
129760547948096["my_id"]
129760547947952["name"]
129760547947520["phone"]
129760547947664["address"]
end

subgraph 129760547948336 ["CTE: cte2 AS cte2"]
129760547947760["my_id"]
129760547948048["name"]
129760547948000["phone"]
129760547948288["address"]
end

subgraph 129760547947568 ["Select: Union Slot#2"]
129760547948384["my_id"]
129760547948480["name"]
129760547948432["phone"]
129760547948672["address"]
end
129760547947760 --> 129760547948384
129760547948048 --> 129760547948480
129760547948000 --> 129760547948432
129760547948288 --> 129760547948672

subgraph 129760547535840 ["Union: Union"]
129760547536128["id"]
129760547536416["name"]
129760547536656["phone"]
129760547536224["address"]
end
129760547947328 --> 129760547536128
129760547948096 --> 129760547536128
129760547948384 --> 129760547536128
129760547947376 --> 129760547536416
129760547947952 --> 129760547536416
129760547948480 --> 129760547536416
129760547947856 --> 129760547536656
129760547947520 --> 129760547536656
129760547948432 --> 129760547536656
129760547536080 --> 129760547536224
129760547947664 --> 129760547536224
129760547948672 --> 129760547536224
```