### PR TITLE
feat: support parse lineage for scalar subquery

### DIFF
--- a/tests/lineage/lineage_conf.yaml
+++ b/tests/lineage/lineage_conf.yaml
@@ -28,3 +28,9 @@
   schema_path: schema.json
   dialect:
   output_type: json
+- path: test_cases/test_scalar_subquery
+  input_path: input.sql
+  output_path: json_output.json
+  schema_path: schema.json
+  dialect:
+  output_type: json

--- a/tests/lineage/test_cases/test_scalar_subquery/input.sql
+++ b/tests/lineage/test_cases/test_scalar_subquery/input.sql
@@ -1,0 +1,19 @@
+with cte1 as (
+    select id, name, phone, address from catalog.schema1.customer
+    where name like 'duy%'
+)
+, tmp_cte as (
+select id, name, age, phone, customer_job from catalog.schema1.user_demographics
+)
+, cte2 as (
+select id, name, age, phone, customer_job job from tmp_cte
+)
+, cte3 as (
+select id, name, age, phone, job from catalog.schema1.tbl_cte3
+)
+select * from (
+select t1.*, concat(t1.name, t2.name) as full_name, max(age) as max_age, (SELECT MAX(id) AS max_id FROM catalog.schema1.customer) as maxid
+from cte1 t1 left join cte2 t2 on t1.phone = t2.phone
+group by t1.id, concat(t1.name, t2.name)
+having max(age) > 10
+) where id < 5

--- a/tests/lineage/test_cases/test_scalar_subquery/json_output.json
+++ b/tests/lineage/test_cases/test_scalar_subquery/json_output.json
@@ -1,0 +1,1271 @@
+{
+    "name": "myroot",
+    "expression": "ANCHOR",
+    "generated_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'), \"tmp_cte\" AS (SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"), \"cte2\" AS (SELECT \"tmp_cte\".\"id\" AS \"id\", \"tmp_cte\".\"name\" AS \"name\", \"tmp_cte\".\"age\" AS \"age\", \"tmp_cte\".\"phone\" AS \"phone\", \"tmp_cte\".\"customer_job\" AS \"job\" FROM \"tmp_cte\" AS \"tmp_cte\"), \"cte3\" AS (SELECT \"tbl_cte3\".\"id\" AS \"id\", \"tbl_cte3\".\"name\" AS \"name\", \"tbl_cte3\".\"age\" AS \"age\", \"tbl_cte3\".\"phone\" AS \"phone\", \"tbl_cte3\".\"job\" AS \"job\" FROM \"catalog\".\"schema1\".\"tbl_cte3\" AS \"tbl_cte3\") SELECT \"_q_0\".\"id\" AS \"id\", \"_q_0\".\"name\" AS \"name\", \"_q_0\".\"phone\" AS \"phone\", \"_q_0\".\"address\" AS \"address\", \"_q_0\".\"full_name\" AS \"full_name\", \"_q_0\".\"max_age\" AS \"max_age\", \"_q_0\".\"maxid\" AS \"maxid\" FROM (SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10) AS \"_q_0\" WHERE \"_q_0\".\"id\" < 5",
+    "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'), \"tmp_cte\" AS (SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"), \"cte2\" AS (SELECT \"tmp_cte\".\"id\" AS \"id\", \"tmp_cte\".\"name\" AS \"name\", \"tmp_cte\".\"age\" AS \"age\", \"tmp_cte\".\"phone\" AS \"phone\", \"tmp_cte\".\"customer_job\" AS \"job\" FROM \"tmp_cte\" AS \"tmp_cte\"), \"cte3\" AS (SELECT \"tbl_cte3\".\"id\" AS \"id\", \"tbl_cte3\".\"name\" AS \"name\", \"tbl_cte3\".\"age\" AS \"age\", \"tbl_cte3\".\"phone\" AS \"phone\", \"tbl_cte3\".\"job\" AS \"job\" FROM \"catalog\".\"schema1\".\"tbl_cte3\" AS \"tbl_cte3\") SELECT \"_q_0\".\"id\" AS \"id\", \"_q_0\".\"name\" AS \"name\", \"_q_0\".\"phone\" AS \"phone\", \"_q_0\".\"address\" AS \"address\", \"_q_0\".\"full_name\" AS \"full_name\", \"_q_0\".\"max_age\" AS \"max_age\", \"_q_0\".\"maxid\" AS \"maxid\" FROM (SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10) AS \"_q_0\" WHERE \"_q_0\".\"id\" < 5",
+    "node_type": "Select",
+    "children": [],
+    "downstreams": [
+        {
+            "name": "_output_",
+            "expression": "catalog.myschema.ROOT_TABLE",
+            "generated_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'), \"tmp_cte\" AS (SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"), \"cte2\" AS (SELECT \"tmp_cte\".\"id\" AS \"id\", \"tmp_cte\".\"name\" AS \"name\", \"tmp_cte\".\"age\" AS \"age\", \"tmp_cte\".\"phone\" AS \"phone\", \"tmp_cte\".\"customer_job\" AS \"job\" FROM \"tmp_cte\" AS \"tmp_cte\"), \"cte3\" AS (SELECT \"tbl_cte3\".\"id\" AS \"id\", \"tbl_cte3\".\"name\" AS \"name\", \"tbl_cte3\".\"age\" AS \"age\", \"tbl_cte3\".\"phone\" AS \"phone\", \"tbl_cte3\".\"job\" AS \"job\" FROM \"catalog\".\"schema1\".\"tbl_cte3\" AS \"tbl_cte3\") SELECT \"_q_0\".\"id\" AS \"id\", \"_q_0\".\"name\" AS \"name\", \"_q_0\".\"phone\" AS \"phone\", \"_q_0\".\"address\" AS \"address\", \"_q_0\".\"full_name\" AS \"full_name\", \"_q_0\".\"max_age\" AS \"max_age\", \"_q_0\".\"maxid\" AS \"maxid\" FROM (SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10) AS \"_q_0\" WHERE \"_q_0\".\"id\" < 5",
+            "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'), \"tmp_cte\" AS (SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"), \"cte2\" AS (SELECT \"tmp_cte\".\"id\" AS \"id\", \"tmp_cte\".\"name\" AS \"name\", \"tmp_cte\".\"age\" AS \"age\", \"tmp_cte\".\"phone\" AS \"phone\", \"tmp_cte\".\"customer_job\" AS \"job\" FROM \"tmp_cte\" AS \"tmp_cte\"), \"cte3\" AS (SELECT \"tbl_cte3\".\"id\" AS \"id\", \"tbl_cte3\".\"name\" AS \"name\", \"tbl_cte3\".\"age\" AS \"age\", \"tbl_cte3\".\"phone\" AS \"phone\", \"tbl_cte3\".\"job\" AS \"job\" FROM \"catalog\".\"schema1\".\"tbl_cte3\" AS \"tbl_cte3\") SELECT \"_q_0\".\"id\" AS \"id\", \"_q_0\".\"name\" AS \"name\", \"_q_0\".\"phone\" AS \"phone\", \"_q_0\".\"address\" AS \"address\", \"_q_0\".\"full_name\" AS \"full_name\", \"_q_0\".\"max_age\" AS \"max_age\", \"_q_0\".\"maxid\" AS \"maxid\" FROM (SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10) AS \"_q_0\" WHERE \"_q_0\".\"id\" < 5",
+            "node_type": "Select",
+            "children": [
+                {
+                    "name": "id",
+                    "expression": "\"_q_0\".\"id\"",
+                    "generated_expression": "\"_q_0\".\"id\"",
+                    "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'), \"tmp_cte\" AS (SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"), \"cte2\" AS (SELECT \"tmp_cte\".\"id\" AS \"id\", \"tmp_cte\".\"name\" AS \"name\", \"tmp_cte\".\"age\" AS \"age\", \"tmp_cte\".\"phone\" AS \"phone\", \"tmp_cte\".\"customer_job\" AS \"job\" FROM \"tmp_cte\" AS \"tmp_cte\"), \"cte3\" AS (SELECT \"tbl_cte3\".\"id\" AS \"id\", \"tbl_cte3\".\"name\" AS \"name\", \"tbl_cte3\".\"age\" AS \"age\", \"tbl_cte3\".\"phone\" AS \"phone\", \"tbl_cte3\".\"job\" AS \"job\" FROM \"catalog\".\"schema1\".\"tbl_cte3\" AS \"tbl_cte3\") SELECT \"_q_0\".\"id\" AS \"id\", \"_q_0\".\"name\" AS \"name\", \"_q_0\".\"phone\" AS \"phone\", \"_q_0\".\"address\" AS \"address\", \"_q_0\".\"full_name\" AS \"full_name\", \"_q_0\".\"max_age\" AS \"max_age\", \"_q_0\".\"maxid\" AS \"maxid\" FROM (SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10) AS \"_q_0\" WHERE \"_q_0\".\"id\" < 5",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "id",
+                            "expression": "\"t1\".\"id\"",
+                            "generated_expression": "\"t1\".\"id\"",
+                            "source_expression": "SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "id",
+                                    "expression": "\"customer\".\"id\"",
+                                    "generated_expression": "\"customer\".\"id\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "id",
+                                            "expression": "id",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "name",
+                    "expression": "\"_q_0\".\"name\"",
+                    "generated_expression": "\"_q_0\".\"name\"",
+                    "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'), \"tmp_cte\" AS (SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"), \"cte2\" AS (SELECT \"tmp_cte\".\"id\" AS \"id\", \"tmp_cte\".\"name\" AS \"name\", \"tmp_cte\".\"age\" AS \"age\", \"tmp_cte\".\"phone\" AS \"phone\", \"tmp_cte\".\"customer_job\" AS \"job\" FROM \"tmp_cte\" AS \"tmp_cte\"), \"cte3\" AS (SELECT \"tbl_cte3\".\"id\" AS \"id\", \"tbl_cte3\".\"name\" AS \"name\", \"tbl_cte3\".\"age\" AS \"age\", \"tbl_cte3\".\"phone\" AS \"phone\", \"tbl_cte3\".\"job\" AS \"job\" FROM \"catalog\".\"schema1\".\"tbl_cte3\" AS \"tbl_cte3\") SELECT \"_q_0\".\"id\" AS \"id\", \"_q_0\".\"name\" AS \"name\", \"_q_0\".\"phone\" AS \"phone\", \"_q_0\".\"address\" AS \"address\", \"_q_0\".\"full_name\" AS \"full_name\", \"_q_0\".\"max_age\" AS \"max_age\", \"_q_0\".\"maxid\" AS \"maxid\" FROM (SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10) AS \"_q_0\" WHERE \"_q_0\".\"id\" < 5",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "name",
+                            "expression": "\"t1\".\"name\"",
+                            "generated_expression": "\"t1\".\"name\"",
+                            "source_expression": "SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "name",
+                                    "expression": "\"customer\".\"name\"",
+                                    "generated_expression": "\"customer\".\"name\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "name",
+                                            "expression": "name",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "phone",
+                    "expression": "\"_q_0\".\"phone\"",
+                    "generated_expression": "\"_q_0\".\"phone\"",
+                    "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'), \"tmp_cte\" AS (SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"), \"cte2\" AS (SELECT \"tmp_cte\".\"id\" AS \"id\", \"tmp_cte\".\"name\" AS \"name\", \"tmp_cte\".\"age\" AS \"age\", \"tmp_cte\".\"phone\" AS \"phone\", \"tmp_cte\".\"customer_job\" AS \"job\" FROM \"tmp_cte\" AS \"tmp_cte\"), \"cte3\" AS (SELECT \"tbl_cte3\".\"id\" AS \"id\", \"tbl_cte3\".\"name\" AS \"name\", \"tbl_cte3\".\"age\" AS \"age\", \"tbl_cte3\".\"phone\" AS \"phone\", \"tbl_cte3\".\"job\" AS \"job\" FROM \"catalog\".\"schema1\".\"tbl_cte3\" AS \"tbl_cte3\") SELECT \"_q_0\".\"id\" AS \"id\", \"_q_0\".\"name\" AS \"name\", \"_q_0\".\"phone\" AS \"phone\", \"_q_0\".\"address\" AS \"address\", \"_q_0\".\"full_name\" AS \"full_name\", \"_q_0\".\"max_age\" AS \"max_age\", \"_q_0\".\"maxid\" AS \"maxid\" FROM (SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10) AS \"_q_0\" WHERE \"_q_0\".\"id\" < 5",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "phone",
+                            "expression": "\"t1\".\"phone\"",
+                            "generated_expression": "\"t1\".\"phone\"",
+                            "source_expression": "SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "phone",
+                                    "expression": "\"customer\".\"phone\"",
+                                    "generated_expression": "\"customer\".\"phone\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "phone",
+                                            "expression": "phone",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "address",
+                    "expression": "\"_q_0\".\"address\"",
+                    "generated_expression": "\"_q_0\".\"address\"",
+                    "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'), \"tmp_cte\" AS (SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"), \"cte2\" AS (SELECT \"tmp_cte\".\"id\" AS \"id\", \"tmp_cte\".\"name\" AS \"name\", \"tmp_cte\".\"age\" AS \"age\", \"tmp_cte\".\"phone\" AS \"phone\", \"tmp_cte\".\"customer_job\" AS \"job\" FROM \"tmp_cte\" AS \"tmp_cte\"), \"cte3\" AS (SELECT \"tbl_cte3\".\"id\" AS \"id\", \"tbl_cte3\".\"name\" AS \"name\", \"tbl_cte3\".\"age\" AS \"age\", \"tbl_cte3\".\"phone\" AS \"phone\", \"tbl_cte3\".\"job\" AS \"job\" FROM \"catalog\".\"schema1\".\"tbl_cte3\" AS \"tbl_cte3\") SELECT \"_q_0\".\"id\" AS \"id\", \"_q_0\".\"name\" AS \"name\", \"_q_0\".\"phone\" AS \"phone\", \"_q_0\".\"address\" AS \"address\", \"_q_0\".\"full_name\" AS \"full_name\", \"_q_0\".\"max_age\" AS \"max_age\", \"_q_0\".\"maxid\" AS \"maxid\" FROM (SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10) AS \"_q_0\" WHERE \"_q_0\".\"id\" < 5",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "address",
+                            "expression": "\"t1\".\"address\"",
+                            "generated_expression": "\"t1\".\"address\"",
+                            "source_expression": "SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "address",
+                                    "expression": "\"customer\".\"address\"",
+                                    "generated_expression": "\"customer\".\"address\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "address",
+                                            "expression": "address",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "full_name",
+                    "expression": "\"_q_0\".\"full_name\"",
+                    "generated_expression": "\"_q_0\".\"full_name\"",
+                    "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'), \"tmp_cte\" AS (SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"), \"cte2\" AS (SELECT \"tmp_cte\".\"id\" AS \"id\", \"tmp_cte\".\"name\" AS \"name\", \"tmp_cte\".\"age\" AS \"age\", \"tmp_cte\".\"phone\" AS \"phone\", \"tmp_cte\".\"customer_job\" AS \"job\" FROM \"tmp_cte\" AS \"tmp_cte\"), \"cte3\" AS (SELECT \"tbl_cte3\".\"id\" AS \"id\", \"tbl_cte3\".\"name\" AS \"name\", \"tbl_cte3\".\"age\" AS \"age\", \"tbl_cte3\".\"phone\" AS \"phone\", \"tbl_cte3\".\"job\" AS \"job\" FROM \"catalog\".\"schema1\".\"tbl_cte3\" AS \"tbl_cte3\") SELECT \"_q_0\".\"id\" AS \"id\", \"_q_0\".\"name\" AS \"name\", \"_q_0\".\"phone\" AS \"phone\", \"_q_0\".\"address\" AS \"address\", \"_q_0\".\"full_name\" AS \"full_name\", \"_q_0\".\"max_age\" AS \"max_age\", \"_q_0\".\"maxid\" AS \"maxid\" FROM (SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10) AS \"_q_0\" WHERE \"_q_0\".\"id\" < 5",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "full_name",
+                            "expression": "CONCAT(\"t1\".\"name\", \"t2\".\"name\")",
+                            "generated_expression": "CONCAT(\"t1\".\"name\", \"t2\".\"name\")",
+                            "source_expression": "SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "name",
+                                    "expression": "\"customer\".\"name\"",
+                                    "generated_expression": "\"customer\".\"name\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "name",
+                                            "expression": "name",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "name",
+                                    "expression": "\"tmp_cte\".\"name\"",
+                                    "generated_expression": "\"tmp_cte\".\"name\"",
+                                    "source_expression": "SELECT \"tmp_cte\".\"id\" AS \"id\", \"tmp_cte\".\"name\" AS \"name\", \"tmp_cte\".\"age\" AS \"age\", \"tmp_cte\".\"phone\" AS \"phone\", \"tmp_cte\".\"customer_job\" AS \"job\" FROM \"tmp_cte\" AS \"tmp_cte\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "name",
+                                            "expression": "\"user_demographics\".\"name\"",
+                                            "generated_expression": "\"user_demographics\".\"name\"",
+                                            "source_expression": "SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": [
+                                                {
+                                                    "name": "name",
+                                                    "expression": "name",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "max_age",
+                    "expression": "\"_q_0\".\"max_age\"",
+                    "generated_expression": "\"_q_0\".\"max_age\"",
+                    "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'), \"tmp_cte\" AS (SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"), \"cte2\" AS (SELECT \"tmp_cte\".\"id\" AS \"id\", \"tmp_cte\".\"name\" AS \"name\", \"tmp_cte\".\"age\" AS \"age\", \"tmp_cte\".\"phone\" AS \"phone\", \"tmp_cte\".\"customer_job\" AS \"job\" FROM \"tmp_cte\" AS \"tmp_cte\"), \"cte3\" AS (SELECT \"tbl_cte3\".\"id\" AS \"id\", \"tbl_cte3\".\"name\" AS \"name\", \"tbl_cte3\".\"age\" AS \"age\", \"tbl_cte3\".\"phone\" AS \"phone\", \"tbl_cte3\".\"job\" AS \"job\" FROM \"catalog\".\"schema1\".\"tbl_cte3\" AS \"tbl_cte3\") SELECT \"_q_0\".\"id\" AS \"id\", \"_q_0\".\"name\" AS \"name\", \"_q_0\".\"phone\" AS \"phone\", \"_q_0\".\"address\" AS \"address\", \"_q_0\".\"full_name\" AS \"full_name\", \"_q_0\".\"max_age\" AS \"max_age\", \"_q_0\".\"maxid\" AS \"maxid\" FROM (SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10) AS \"_q_0\" WHERE \"_q_0\".\"id\" < 5",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "max_age",
+                            "expression": "MAX(\"t2\".\"age\")",
+                            "generated_expression": "MAX(\"t2\".\"age\")",
+                            "source_expression": "SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "age",
+                                    "expression": "\"tmp_cte\".\"age\"",
+                                    "generated_expression": "\"tmp_cte\".\"age\"",
+                                    "source_expression": "SELECT \"tmp_cte\".\"id\" AS \"id\", \"tmp_cte\".\"name\" AS \"name\", \"tmp_cte\".\"age\" AS \"age\", \"tmp_cte\".\"phone\" AS \"phone\", \"tmp_cte\".\"customer_job\" AS \"job\" FROM \"tmp_cte\" AS \"tmp_cte\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "age",
+                                            "expression": "\"user_demographics\".\"age\"",
+                                            "generated_expression": "\"user_demographics\".\"age\"",
+                                            "source_expression": "SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": [
+                                                {
+                                                    "name": "age",
+                                                    "expression": "age",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "maxid",
+                    "expression": "\"_q_0\".\"maxid\"",
+                    "generated_expression": "\"_q_0\".\"maxid\"",
+                    "source_expression": "WITH \"cte1\" AS (SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'), \"tmp_cte\" AS (SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"), \"cte2\" AS (SELECT \"tmp_cte\".\"id\" AS \"id\", \"tmp_cte\".\"name\" AS \"name\", \"tmp_cte\".\"age\" AS \"age\", \"tmp_cte\".\"phone\" AS \"phone\", \"tmp_cte\".\"customer_job\" AS \"job\" FROM \"tmp_cte\" AS \"tmp_cte\"), \"cte3\" AS (SELECT \"tbl_cte3\".\"id\" AS \"id\", \"tbl_cte3\".\"name\" AS \"name\", \"tbl_cte3\".\"age\" AS \"age\", \"tbl_cte3\".\"phone\" AS \"phone\", \"tbl_cte3\".\"job\" AS \"job\" FROM \"catalog\".\"schema1\".\"tbl_cte3\" AS \"tbl_cte3\") SELECT \"_q_0\".\"id\" AS \"id\", \"_q_0\".\"name\" AS \"name\", \"_q_0\".\"phone\" AS \"phone\", \"_q_0\".\"address\" AS \"address\", \"_q_0\".\"full_name\" AS \"full_name\", \"_q_0\".\"max_age\" AS \"max_age\", \"_q_0\".\"maxid\" AS \"maxid\" FROM (SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10) AS \"_q_0\" WHERE \"_q_0\".\"id\" < 5",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "maxid",
+                            "expression": "(SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\")",
+                            "generated_expression": "(SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\")",
+                            "source_expression": "SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "Scalar subquery",
+                                    "expression": "\"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                    "generated_expression": "SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                    "source_expression": "SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                    "node_type": "Select",
+                                    "children": [
+                                        {
+                                            "name": "max_id",
+                                            "expression": "MAX(\"customer\".\"id\")",
+                                            "generated_expression": "MAX(\"customer\".\"id\")",
+                                            "source_expression": "SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": [
+                                                {
+                                                    "name": "id",
+                                                    "expression": "id",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "downstreams": [
+                                        {
+                                            "name": "\"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "expression": "\"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "generated_expression": null,
+                                            "source_expression": null,
+                                            "node_type": "Table",
+                                            "children": [
+                                                {
+                                                    "name": "id",
+                                                    "expression": "id",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                },
+                                                {
+                                                    "name": "name",
+                                                    "expression": "name",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                },
+                                                {
+                                                    "name": "phone",
+                                                    "expression": "phone",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                },
+                                                {
+                                                    "name": "address",
+                                                    "expression": "address",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                },
+                                                {
+                                                    "name": "location",
+                                                    "expression": "location",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                }
+                                            ],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "downstreams": [
+                {
+                    "name": "_q_0",
+                    "expression": "(SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10) AS \"_q_0\"",
+                    "generated_expression": "SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10",
+                    "source_expression": "SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10",
+                    "node_type": "Subquery",
+                    "children": [
+                        {
+                            "name": "id",
+                            "expression": "\"t1\".\"id\"",
+                            "generated_expression": "\"t1\".\"id\"",
+                            "source_expression": "SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "id",
+                                    "expression": "\"customer\".\"id\"",
+                                    "generated_expression": "\"customer\".\"id\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "id",
+                                            "expression": "id",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "name",
+                            "expression": "\"t1\".\"name\"",
+                            "generated_expression": "\"t1\".\"name\"",
+                            "source_expression": "SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "name",
+                                    "expression": "\"customer\".\"name\"",
+                                    "generated_expression": "\"customer\".\"name\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "name",
+                                            "expression": "name",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "phone",
+                            "expression": "\"t1\".\"phone\"",
+                            "generated_expression": "\"t1\".\"phone\"",
+                            "source_expression": "SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "phone",
+                                    "expression": "\"customer\".\"phone\"",
+                                    "generated_expression": "\"customer\".\"phone\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "phone",
+                                            "expression": "phone",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "address",
+                            "expression": "\"t1\".\"address\"",
+                            "generated_expression": "\"t1\".\"address\"",
+                            "source_expression": "SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "address",
+                                    "expression": "\"customer\".\"address\"",
+                                    "generated_expression": "\"customer\".\"address\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "address",
+                                            "expression": "address",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "full_name",
+                            "expression": "CONCAT(\"t1\".\"name\", \"t2\".\"name\")",
+                            "generated_expression": "CONCAT(\"t1\".\"name\", \"t2\".\"name\")",
+                            "source_expression": "SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "name",
+                                    "expression": "\"customer\".\"name\"",
+                                    "generated_expression": "\"customer\".\"name\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "name",
+                                            "expression": "name",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "name",
+                                    "expression": "\"tmp_cte\".\"name\"",
+                                    "generated_expression": "\"tmp_cte\".\"name\"",
+                                    "source_expression": "SELECT \"tmp_cte\".\"id\" AS \"id\", \"tmp_cte\".\"name\" AS \"name\", \"tmp_cte\".\"age\" AS \"age\", \"tmp_cte\".\"phone\" AS \"phone\", \"tmp_cte\".\"customer_job\" AS \"job\" FROM \"tmp_cte\" AS \"tmp_cte\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "name",
+                                            "expression": "\"user_demographics\".\"name\"",
+                                            "generated_expression": "\"user_demographics\".\"name\"",
+                                            "source_expression": "SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": [
+                                                {
+                                                    "name": "name",
+                                                    "expression": "name",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "max_age",
+                            "expression": "MAX(\"t2\".\"age\")",
+                            "generated_expression": "MAX(\"t2\".\"age\")",
+                            "source_expression": "SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "age",
+                                    "expression": "\"tmp_cte\".\"age\"",
+                                    "generated_expression": "\"tmp_cte\".\"age\"",
+                                    "source_expression": "SELECT \"tmp_cte\".\"id\" AS \"id\", \"tmp_cte\".\"name\" AS \"name\", \"tmp_cte\".\"age\" AS \"age\", \"tmp_cte\".\"phone\" AS \"phone\", \"tmp_cte\".\"customer_job\" AS \"job\" FROM \"tmp_cte\" AS \"tmp_cte\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "age",
+                                            "expression": "\"user_demographics\".\"age\"",
+                                            "generated_expression": "\"user_demographics\".\"age\"",
+                                            "source_expression": "SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": [
+                                                {
+                                                    "name": "age",
+                                                    "expression": "age",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "maxid",
+                            "expression": "(SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\")",
+                            "generated_expression": "(SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\")",
+                            "source_expression": "SELECT \"t1\".\"id\" AS \"id\", \"t1\".\"name\" AS \"name\", \"t1\".\"phone\" AS \"phone\", \"t1\".\"address\" AS \"address\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") AS \"full_name\", MAX(\"t2\".\"age\") AS \"max_age\", (SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\") AS \"maxid\" FROM \"cte1\" AS \"t1\" LEFT JOIN \"cte2\" AS \"t2\" ON \"t1\".\"phone\" = \"t2\".\"phone\" GROUP BY \"t1\".\"id\", CONCAT(\"t1\".\"name\", \"t2\".\"name\") HAVING MAX(\"t2\".\"age\") > 10",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "Scalar subquery",
+                                    "expression": "\"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                    "generated_expression": "SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                    "source_expression": "SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                    "node_type": "Select",
+                                    "children": [
+                                        {
+                                            "name": "max_id",
+                                            "expression": "MAX(\"customer\".\"id\")",
+                                            "generated_expression": "MAX(\"customer\".\"id\")",
+                                            "source_expression": "SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": [
+                                                {
+                                                    "name": "id",
+                                                    "expression": "id",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "downstreams": [
+                                        {
+                                            "name": "\"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "expression": "\"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "generated_expression": null,
+                                            "source_expression": null,
+                                            "node_type": "Table",
+                                            "children": [
+                                                {
+                                                    "name": "id",
+                                                    "expression": "id",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                },
+                                                {
+                                                    "name": "name",
+                                                    "expression": "name",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                },
+                                                {
+                                                    "name": "phone",
+                                                    "expression": "phone",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                },
+                                                {
+                                                    "name": "address",
+                                                    "expression": "address",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                },
+                                                {
+                                                    "name": "location",
+                                                    "expression": "location",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                }
+                                            ],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "downstreams": [
+                        {
+                            "name": "\"cte1\" AS \"t1\"",
+                            "expression": "\"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                            "generated_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'",
+                            "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'",
+                            "node_type": "CTE",
+                            "children": [
+                                {
+                                    "name": "id",
+                                    "expression": "\"customer\".\"id\"",
+                                    "generated_expression": "\"customer\".\"id\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "id",
+                                            "expression": "id",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "name",
+                                    "expression": "\"customer\".\"name\"",
+                                    "generated_expression": "\"customer\".\"name\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "name",
+                                            "expression": "name",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "phone",
+                                    "expression": "\"customer\".\"phone\"",
+                                    "generated_expression": "\"customer\".\"phone\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "phone",
+                                            "expression": "phone",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "address",
+                                    "expression": "\"customer\".\"address\"",
+                                    "generated_expression": "\"customer\".\"address\"",
+                                    "source_expression": "SELECT \"customer\".\"id\" AS \"id\", \"customer\".\"name\" AS \"name\", \"customer\".\"phone\" AS \"phone\", \"customer\".\"address\" AS \"address\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\" WHERE \"customer\".\"name\" LIKE 'duy%'",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "address",
+                                            "expression": "address",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ],
+                            "downstreams": [
+                                {
+                                    "name": "\"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                    "expression": "\"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                    "generated_expression": null,
+                                    "source_expression": null,
+                                    "node_type": "Table",
+                                    "children": [
+                                        {
+                                            "name": "id",
+                                            "expression": "id",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        },
+                                        {
+                                            "name": "name",
+                                            "expression": "name",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        },
+                                        {
+                                            "name": "phone",
+                                            "expression": "phone",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        },
+                                        {
+                                            "name": "address",
+                                            "expression": "address",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        },
+                                        {
+                                            "name": "location",
+                                            "expression": "location",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ],
+                                    "downstreams": []
+                                }
+                            ]
+                        },
+                        {
+                            "name": "\"cte2\" AS \"t2\"",
+                            "expression": "\"tmp_cte\" AS \"tmp_cte\"",
+                            "generated_expression": "SELECT \"tmp_cte\".\"id\" AS \"id\", \"tmp_cte\".\"name\" AS \"name\", \"tmp_cte\".\"age\" AS \"age\", \"tmp_cte\".\"phone\" AS \"phone\", \"tmp_cte\".\"customer_job\" AS \"job\" FROM \"tmp_cte\" AS \"tmp_cte\"",
+                            "source_expression": "SELECT \"tmp_cte\".\"id\" AS \"id\", \"tmp_cte\".\"name\" AS \"name\", \"tmp_cte\".\"age\" AS \"age\", \"tmp_cte\".\"phone\" AS \"phone\", \"tmp_cte\".\"customer_job\" AS \"job\" FROM \"tmp_cte\" AS \"tmp_cte\"",
+                            "node_type": "CTE",
+                            "children": [
+                                {
+                                    "name": "id",
+                                    "expression": "\"tmp_cte\".\"id\"",
+                                    "generated_expression": "\"tmp_cte\".\"id\"",
+                                    "source_expression": "SELECT \"tmp_cte\".\"id\" AS \"id\", \"tmp_cte\".\"name\" AS \"name\", \"tmp_cte\".\"age\" AS \"age\", \"tmp_cte\".\"phone\" AS \"phone\", \"tmp_cte\".\"customer_job\" AS \"job\" FROM \"tmp_cte\" AS \"tmp_cte\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "id",
+                                            "expression": "\"user_demographics\".\"id\"",
+                                            "generated_expression": "\"user_demographics\".\"id\"",
+                                            "source_expression": "SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": [
+                                                {
+                                                    "name": "id",
+                                                    "expression": "id",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "name",
+                                    "expression": "\"tmp_cte\".\"name\"",
+                                    "generated_expression": "\"tmp_cte\".\"name\"",
+                                    "source_expression": "SELECT \"tmp_cte\".\"id\" AS \"id\", \"tmp_cte\".\"name\" AS \"name\", \"tmp_cte\".\"age\" AS \"age\", \"tmp_cte\".\"phone\" AS \"phone\", \"tmp_cte\".\"customer_job\" AS \"job\" FROM \"tmp_cte\" AS \"tmp_cte\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "name",
+                                            "expression": "\"user_demographics\".\"name\"",
+                                            "generated_expression": "\"user_demographics\".\"name\"",
+                                            "source_expression": "SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": [
+                                                {
+                                                    "name": "name",
+                                                    "expression": "name",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "age",
+                                    "expression": "\"tmp_cte\".\"age\"",
+                                    "generated_expression": "\"tmp_cte\".\"age\"",
+                                    "source_expression": "SELECT \"tmp_cte\".\"id\" AS \"id\", \"tmp_cte\".\"name\" AS \"name\", \"tmp_cte\".\"age\" AS \"age\", \"tmp_cte\".\"phone\" AS \"phone\", \"tmp_cte\".\"customer_job\" AS \"job\" FROM \"tmp_cte\" AS \"tmp_cte\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "age",
+                                            "expression": "\"user_demographics\".\"age\"",
+                                            "generated_expression": "\"user_demographics\".\"age\"",
+                                            "source_expression": "SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": [
+                                                {
+                                                    "name": "age",
+                                                    "expression": "age",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "phone",
+                                    "expression": "\"tmp_cte\".\"phone\"",
+                                    "generated_expression": "\"tmp_cte\".\"phone\"",
+                                    "source_expression": "SELECT \"tmp_cte\".\"id\" AS \"id\", \"tmp_cte\".\"name\" AS \"name\", \"tmp_cte\".\"age\" AS \"age\", \"tmp_cte\".\"phone\" AS \"phone\", \"tmp_cte\".\"customer_job\" AS \"job\" FROM \"tmp_cte\" AS \"tmp_cte\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "phone",
+                                            "expression": "\"user_demographics\".\"phone\"",
+                                            "generated_expression": "\"user_demographics\".\"phone\"",
+                                            "source_expression": "SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": [
+                                                {
+                                                    "name": "phone",
+                                                    "expression": "phone",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "job",
+                                    "expression": "\"tmp_cte\".\"customer_job\"",
+                                    "generated_expression": "\"tmp_cte\".\"customer_job\"",
+                                    "source_expression": "SELECT \"tmp_cte\".\"id\" AS \"id\", \"tmp_cte\".\"name\" AS \"name\", \"tmp_cte\".\"age\" AS \"age\", \"tmp_cte\".\"phone\" AS \"phone\", \"tmp_cte\".\"customer_job\" AS \"job\" FROM \"tmp_cte\" AS \"tmp_cte\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "customer_job",
+                                            "expression": "\"user_demographics\".\"customer_job\"",
+                                            "generated_expression": "\"user_demographics\".\"customer_job\"",
+                                            "source_expression": "SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": [
+                                                {
+                                                    "name": "customer_job",
+                                                    "expression": "customer_job",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "downstreams": [
+                                {
+                                    "name": "\"tmp_cte\" AS \"tmp_cte\"",
+                                    "expression": "\"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                    "generated_expression": "SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                    "source_expression": "SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                    "node_type": "CTE",
+                                    "children": [
+                                        {
+                                            "name": "id",
+                                            "expression": "\"user_demographics\".\"id\"",
+                                            "generated_expression": "\"user_demographics\".\"id\"",
+                                            "source_expression": "SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": [
+                                                {
+                                                    "name": "id",
+                                                    "expression": "id",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "name": "name",
+                                            "expression": "\"user_demographics\".\"name\"",
+                                            "generated_expression": "\"user_demographics\".\"name\"",
+                                            "source_expression": "SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": [
+                                                {
+                                                    "name": "name",
+                                                    "expression": "name",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "name": "age",
+                                            "expression": "\"user_demographics\".\"age\"",
+                                            "generated_expression": "\"user_demographics\".\"age\"",
+                                            "source_expression": "SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": [
+                                                {
+                                                    "name": "age",
+                                                    "expression": "age",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "name": "phone",
+                                            "expression": "\"user_demographics\".\"phone\"",
+                                            "generated_expression": "\"user_demographics\".\"phone\"",
+                                            "source_expression": "SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": [
+                                                {
+                                                    "name": "phone",
+                                                    "expression": "phone",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "name": "customer_job",
+                                            "expression": "\"user_demographics\".\"customer_job\"",
+                                            "generated_expression": "\"user_demographics\".\"customer_job\"",
+                                            "source_expression": "SELECT \"user_demographics\".\"id\" AS \"id\", \"user_demographics\".\"name\" AS \"name\", \"user_demographics\".\"age\" AS \"age\", \"user_demographics\".\"phone\" AS \"phone\", \"user_demographics\".\"customer_job\" AS \"customer_job\" FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": [
+                                                {
+                                                    "name": "customer_job",
+                                                    "expression": "customer_job",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "downstreams": [
+                                        {
+                                            "name": "\"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                            "expression": "\"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                            "generated_expression": null,
+                                            "source_expression": null,
+                                            "node_type": "Table",
+                                            "children": [
+                                                {
+                                                    "name": "id",
+                                                    "expression": "id",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                },
+                                                {
+                                                    "name": "name",
+                                                    "expression": "name",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                },
+                                                {
+                                                    "name": "age",
+                                                    "expression": "age",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                },
+                                                {
+                                                    "name": "phone",
+                                                    "expression": "phone",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                },
+                                                {
+                                                    "name": "customer_job",
+                                                    "expression": "customer_job",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                },
+                                                {
+                                                    "name": "parent",
+                                                    "expression": "parent",
+                                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "source_expression": "FROM \"catalog\".\"schema1\".\"user_demographics\" AS \"user_demographics\"",
+                                                    "node_type": "Column",
+                                                    "children": [],
+                                                    "downstreams": []
+                                                }
+                                            ],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "Scalar subquery",
+                            "expression": "\"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                            "generated_expression": "SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                            "source_expression": "SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                            "node_type": "Select",
+                            "children": [
+                                {
+                                    "name": "max_id",
+                                    "expression": "MAX(\"customer\".\"id\")",
+                                    "generated_expression": "MAX(\"customer\".\"id\")",
+                                    "source_expression": "SELECT MAX(\"customer\".\"id\") AS \"max_id\" FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": [
+                                        {
+                                            "name": "id",
+                                            "expression": "id",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ]
+                                }
+                            ],
+                            "downstreams": [
+                                {
+                                    "name": "\"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                    "expression": "\"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                    "generated_expression": null,
+                                    "source_expression": null,
+                                    "node_type": "Table",
+                                    "children": [
+                                        {
+                                            "name": "id",
+                                            "expression": "id",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        },
+                                        {
+                                            "name": "name",
+                                            "expression": "name",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        },
+                                        {
+                                            "name": "phone",
+                                            "expression": "phone",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        },
+                                        {
+                                            "name": "address",
+                                            "expression": "address",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        },
+                                        {
+                                            "name": "location",
+                                            "expression": "location",
+                                            "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"customer\"",
+                                            "node_type": "Column",
+                                            "children": [],
+                                            "downstreams": []
+                                        }
+                                    ],
+                                    "downstreams": []
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/lineage/test_cases/test_scalar_subquery/schema.json
+++ b/tests/lineage/test_cases/test_scalar_subquery/schema.json
@@ -1,0 +1,29 @@
+{
+  "catalog": {
+      "schema1": {
+          "customer": {
+              "id": "INTEGER",
+              "name": "STRING",
+              "phone": "STRING",
+              "address": "STRING",
+              "location": "STRING"
+          },
+          "user_demographics": {
+              "id": "INTEGER",
+              "name": "STRING",
+              "age": "STRING",
+              "phone": "STRING",
+              "customer_job": "STRING",
+              "parent": "STRING"
+          },
+          "tbl_cte3": {
+              "id": "INTEGER",
+              "name": "STRING",
+              "age": "STRING",
+              "phone": "STRING",
+              "address": "STRING",
+              "job": "STRING"
+          }
+      }
+  }
+}


### PR DESCRIPTION
Fixes #19 

Feature: Add support parse lineage for scalar subquery. Only work if the selected columns (or the projections) depend on that scalar subquery. All remaining scalar subquery in WHERE or HAVING will be ignored.



Query:
```sql
SELECT (SELECT MAX(id) AS max_id FROM catalog.schema1.customer) as mid,
    concat((SELECT any_value(name) AS any_name FROM catalog.schema1.customer), 'any') as mname,
```

Mermaid output:
```mermaid
%%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%
graph LR
subgraph 2508145104880 ["Table: catalog.schema1.customer AS customer"]
2508145104976["id"]
2508145112272["name"]
2508145110304["phone"]
2508145102576["address"]
2508148825584["location"]
end

subgraph 2508145114096 ["Select: Scalar subquery"]
2508145103008["max_id"]
end
2508145103008_exp[["MAX(customer.id)"]] ----- 2508145103008
2508145104976 --> 2508145103008

subgraph 2508130637472 ["Table: catalog.schema1.customer AS customer"]
2508148824624["id"]
2508148822896["name"]
2508148822464["phone"]
2508148821696["address"]
2508148822512["location"]
end

subgraph 2508145112128 ["Select: Scalar subquery"]
2508145114864["any_name"]
end
2508145114864_exp[["ANY_VALUE(customer.name)"]] ----- 2508145114864
2508148822896 --> 2508145114864

subgraph 2508144848256 ["Select: _output_"]
2508145106224["mid"]
2508145106992["mname"]
end
2508145114096 --> 2508145106224
2508145106992_exp[["CONCAT((SELECT ANY_VALUE(customer.name) AS any_name FROM catalog.schema1.customer AS customer), 'any')"]] ----- 2508145106992
2508145112128 --> 2508145106992
```


