### PR TITLE
feat!: support merge statement

### DIFF
--- a/datalineage/node.py
+++ b/datalineage/node.py
@@ -36,6 +36,9 @@ class Node:
         self.downstreams.append(downstream)
         return self
 
+    def has_downstream(self, node: "Node") -> bool:
+        return node in self.downstreams
+
     @property
     def parent(self):
         return self._parent

--- a/tests/lineage/lineage_conf.yaml
+++ b/tests/lineage/lineage_conf.yaml
@@ -64,3 +64,15 @@
   schema_path: schema.json
   dialect:
   output_type: json
+- path: test_cases/test_merge
+  input_path: 00_input.sql
+  output_path: 00_json_output.json
+  schema_path: schema.json
+  dialect:
+  output_type: json
+- path: test_cases/test_merge
+  input_path: 01_input.sql
+  output_path: 01_json_output.json
+  schema_path: schema.json
+  dialect:
+  output_type: json

--- a/tests/lineage/test_cases/test_merge/00_input.sql
+++ b/tests/lineage/test_cases/test_merge/00_input.sql
@@ -1,0 +1,11 @@
+merge into catalog.schema1.customer_metric c
+using (
+select c.name, c.phone, null as address, coalesce(mb.state, 'default') as state
+from catalog.schema1.customer c 
+left join catalog.schema1.metric_basis mb on c.address = mb.address
+) d
+on c.name = d.name
+when matched then update set state = COALESCE(c.state, d.state), phone = d.phone
+when not matched by source then update set address = COALESCE(c.address, 'default')
+when not matched then insert(phone, name, address, state, custom_col)
+values(d.phone, d.name, d.address, d.state, 'unknown')

--- a/tests/lineage/test_cases/test_merge/00_json_output.json
+++ b/tests/lineage/test_cases/test_merge/00_json_output.json
@@ -1,0 +1,296 @@
+{
+    "name": "myroot",
+    "expression": "ANCHOR",
+    "generated_expression": "MERGE INTO \"catalog\".\"schema1\".\"customer_metric\" AS \"c\" USING (SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\") AS \"d\" ON \"c\".\"name\" = \"d\".\"name\" WHEN MATCHED THEN UPDATE SET \"state\" = COALESCE(\"c\".\"state\", \"d\".\"state\"), \"phone\" = \"d\".\"phone\" WHEN NOT MATCHED BY SOURCE THEN UPDATE SET \"address\" = COALESCE(\"c\".\"address\", 'default') WHEN NOT MATCHED THEN INSERT (\"phone\", \"name\", \"address\", \"state\", \"custom_col\") VALUES (\"d\".\"phone\", \"d\".\"name\", \"d\".\"address\", \"d\".\"state\", 'unknown')",
+    "source_expression": "MERGE INTO \"catalog\".\"schema1\".\"customer_metric\" AS \"c\" USING (SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\") AS \"d\" ON \"c\".\"name\" = \"d\".\"name\" WHEN MATCHED THEN UPDATE SET \"state\" = COALESCE(\"c\".\"state\", \"d\".\"state\"), \"phone\" = \"d\".\"phone\" WHEN NOT MATCHED BY SOURCE THEN UPDATE SET \"address\" = COALESCE(\"c\".\"address\", 'default') WHEN NOT MATCHED THEN INSERT (\"phone\", \"name\", \"address\", \"state\", \"custom_col\") VALUES (\"d\".\"phone\", \"d\".\"name\", \"d\".\"address\", \"d\".\"state\", 'unknown')",
+    "node_type": "Select",
+    "children": [],
+    "downstreams": [
+        {
+            "name": "\"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+            "expression": "\"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+            "generated_expression": null,
+            "source_expression": null,
+            "node_type": "Table",
+            "children": [
+                {
+                    "name": "name",
+                    "expression": "name",
+                    "generated_expression": "SELECT name FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "source_expression": "SELECT name FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "name",
+                            "expression": "\"c\".\"name\"",
+                            "generated_expression": "\"c\".\"name\"",
+                            "source_expression": "SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "name",
+                                    "expression": "name",
+                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "phone",
+                    "expression": "phone",
+                    "generated_expression": "SELECT phone FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "source_expression": "SELECT phone FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "phone",
+                            "expression": "\"c\".\"phone\"",
+                            "generated_expression": "\"c\".\"phone\"",
+                            "source_expression": "SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "phone",
+                                    "expression": "phone",
+                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "address",
+                    "expression": "address",
+                    "generated_expression": "SELECT address FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "source_expression": "SELECT address FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "address",
+                            "expression": "NULL",
+                            "generated_expression": "NULL",
+                            "source_expression": "SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": []
+                        }
+                    ]
+                },
+                {
+                    "name": "state",
+                    "expression": "state",
+                    "generated_expression": "SELECT state FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "source_expression": "SELECT state FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "state",
+                            "expression": "COALESCE(\"mb\".\"state\", 'default')",
+                            "generated_expression": "COALESCE(\"mb\".\"state\", 'default')",
+                            "source_expression": "SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "state",
+                                    "expression": "state",
+                                    "generated_expression": "LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                                    "source_expression": "LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "custom_col",
+                    "expression": "custom_col",
+                    "generated_expression": "SELECT custom_col FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "source_expression": "SELECT custom_col FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": []
+                }
+            ],
+            "downstreams": [
+                {
+                    "name": "d",
+                    "expression": "SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                    "generated_expression": "SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                    "source_expression": "SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                    "node_type": "Subquery",
+                    "children": [
+                        {
+                            "name": "name",
+                            "expression": "\"c\".\"name\"",
+                            "generated_expression": "\"c\".\"name\"",
+                            "source_expression": "SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "name",
+                                    "expression": "name",
+                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ]
+                        },
+                        {
+                            "name": "phone",
+                            "expression": "\"c\".\"phone\"",
+                            "generated_expression": "\"c\".\"phone\"",
+                            "source_expression": "SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "phone",
+                                    "expression": "phone",
+                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ]
+                        },
+                        {
+                            "name": "address",
+                            "expression": "NULL",
+                            "generated_expression": "NULL",
+                            "source_expression": "SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": []
+                        },
+                        {
+                            "name": "state",
+                            "expression": "COALESCE(\"mb\".\"state\", 'default')",
+                            "generated_expression": "COALESCE(\"mb\".\"state\", 'default')",
+                            "source_expression": "SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "state",
+                                    "expression": "state",
+                                    "generated_expression": "LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                                    "source_expression": "LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ]
+                        }
+                    ],
+                    "downstreams": [
+                        {
+                            "name": "\"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                            "expression": "\"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                            "generated_expression": null,
+                            "source_expression": null,
+                            "node_type": "Table",
+                            "children": [
+                                {
+                                    "name": "id",
+                                    "expression": "id",
+                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                },
+                                {
+                                    "name": "name",
+                                    "expression": "name",
+                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                },
+                                {
+                                    "name": "phone",
+                                    "expression": "phone",
+                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                },
+                                {
+                                    "name": "address",
+                                    "expression": "address",
+                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                },
+                                {
+                                    "name": "location",
+                                    "expression": "location",
+                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                },
+                                {
+                                    "name": "partition",
+                                    "expression": "partition",
+                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ],
+                            "downstreams": []
+                        },
+                        {
+                            "name": "\"catalog\".\"schema1\".\"metric_basis\" AS \"mb\"",
+                            "expression": "\"catalog\".\"schema1\".\"metric_basis\" AS \"mb\"",
+                            "generated_expression": null,
+                            "source_expression": null,
+                            "node_type": "Table",
+                            "children": [
+                                {
+                                    "name": "state",
+                                    "expression": "state",
+                                    "generated_expression": "LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                                    "source_expression": "LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ],
+                            "downstreams": []
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/lineage/test_cases/test_merge/01_input.sql
+++ b/tests/lineage/test_cases/test_merge/01_input.sql
@@ -1,0 +1,11 @@
+merge into catalog.schema1.customer_metric c
+using (
+select c.name, c.phone, null as address, coalesce(mb.state, 'default') as state
+from catalog.schema1.customer c 
+left join catalog.schema1.metric_basis mb on c.address = mb.address
+) d
+on c.name = d.name
+when matched then update set state = COALESCE(c.state, d.state), phone = d.phone
+when not matched by source then update set address = COALESCE(c.address, 'default')
+when not matched then insert
+values(d.name, d.phone, d.address, d.state, 'unknown')

--- a/tests/lineage/test_cases/test_merge/01_json_output.json
+++ b/tests/lineage/test_cases/test_merge/01_json_output.json
@@ -1,0 +1,296 @@
+{
+    "name": "myroot",
+    "expression": "ANCHOR",
+    "generated_expression": "MERGE INTO \"catalog\".\"schema1\".\"customer_metric\" AS \"c\" USING (SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\") AS \"d\" ON \"c\".\"name\" = \"d\".\"name\" WHEN MATCHED THEN UPDATE SET \"state\" = COALESCE(\"c\".\"state\", \"d\".\"state\"), \"phone\" = \"d\".\"phone\" WHEN NOT MATCHED BY SOURCE THEN UPDATE SET \"address\" = COALESCE(\"c\".\"address\", 'default') WHEN NOT MATCHED THEN INSERT VALUES (\"d\".\"name\", \"d\".\"phone\", \"d\".\"address\", \"d\".\"state\", 'unknown')",
+    "source_expression": "MERGE INTO \"catalog\".\"schema1\".\"customer_metric\" AS \"c\" USING (SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\") AS \"d\" ON \"c\".\"name\" = \"d\".\"name\" WHEN MATCHED THEN UPDATE SET \"state\" = COALESCE(\"c\".\"state\", \"d\".\"state\"), \"phone\" = \"d\".\"phone\" WHEN NOT MATCHED BY SOURCE THEN UPDATE SET \"address\" = COALESCE(\"c\".\"address\", 'default') WHEN NOT MATCHED THEN INSERT VALUES (\"d\".\"name\", \"d\".\"phone\", \"d\".\"address\", \"d\".\"state\", 'unknown')",
+    "node_type": "Select",
+    "children": [],
+    "downstreams": [
+        {
+            "name": "\"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+            "expression": "\"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+            "generated_expression": null,
+            "source_expression": null,
+            "node_type": "Table",
+            "children": [
+                {
+                    "name": "name",
+                    "expression": "name",
+                    "generated_expression": "SELECT name FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "source_expression": "SELECT name FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "name",
+                            "expression": "\"c\".\"name\"",
+                            "generated_expression": "\"c\".\"name\"",
+                            "source_expression": "SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "name",
+                                    "expression": "name",
+                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "phone",
+                    "expression": "phone",
+                    "generated_expression": "SELECT phone FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "source_expression": "SELECT phone FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "phone",
+                            "expression": "\"c\".\"phone\"",
+                            "generated_expression": "\"c\".\"phone\"",
+                            "source_expression": "SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "phone",
+                                    "expression": "phone",
+                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "address",
+                    "expression": "address",
+                    "generated_expression": "SELECT address FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "source_expression": "SELECT address FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "address",
+                            "expression": "NULL",
+                            "generated_expression": "NULL",
+                            "source_expression": "SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": []
+                        }
+                    ]
+                },
+                {
+                    "name": "state",
+                    "expression": "state",
+                    "generated_expression": "SELECT state FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "source_expression": "SELECT state FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "state",
+                            "expression": "COALESCE(\"mb\".\"state\", 'default')",
+                            "generated_expression": "COALESCE(\"mb\".\"state\", 'default')",
+                            "source_expression": "SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "state",
+                                    "expression": "state",
+                                    "generated_expression": "LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                                    "source_expression": "LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "custom_col",
+                    "expression": "custom_col",
+                    "generated_expression": "SELECT custom_col FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "source_expression": "SELECT custom_col FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": []
+                }
+            ],
+            "downstreams": [
+                {
+                    "name": "d",
+                    "expression": "SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                    "generated_expression": "SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                    "source_expression": "SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                    "node_type": "Subquery",
+                    "children": [
+                        {
+                            "name": "name",
+                            "expression": "\"c\".\"name\"",
+                            "generated_expression": "\"c\".\"name\"",
+                            "source_expression": "SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "name",
+                                    "expression": "name",
+                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ]
+                        },
+                        {
+                            "name": "phone",
+                            "expression": "\"c\".\"phone\"",
+                            "generated_expression": "\"c\".\"phone\"",
+                            "source_expression": "SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "phone",
+                                    "expression": "phone",
+                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ]
+                        },
+                        {
+                            "name": "address",
+                            "expression": "NULL",
+                            "generated_expression": "NULL",
+                            "source_expression": "SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": []
+                        },
+                        {
+                            "name": "state",
+                            "expression": "COALESCE(\"mb\".\"state\", 'default')",
+                            "generated_expression": "COALESCE(\"mb\".\"state\", 'default')",
+                            "source_expression": "SELECT \"c\".\"name\" AS \"name\", \"c\".\"phone\" AS \"phone\", NULL AS \"address\", COALESCE(\"mb\".\"state\", 'default') AS \"state\" FROM \"catalog\".\"schema1\".\"customer\" AS \"c\" LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": [
+                                {
+                                    "name": "state",
+                                    "expression": "state",
+                                    "generated_expression": "LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                                    "source_expression": "LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ]
+                        }
+                    ],
+                    "downstreams": [
+                        {
+                            "name": "\"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                            "expression": "\"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                            "generated_expression": null,
+                            "source_expression": null,
+                            "node_type": "Table",
+                            "children": [
+                                {
+                                    "name": "id",
+                                    "expression": "id",
+                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                },
+                                {
+                                    "name": "name",
+                                    "expression": "name",
+                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                },
+                                {
+                                    "name": "phone",
+                                    "expression": "phone",
+                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                },
+                                {
+                                    "name": "address",
+                                    "expression": "address",
+                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                },
+                                {
+                                    "name": "location",
+                                    "expression": "location",
+                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                },
+                                {
+                                    "name": "partition",
+                                    "expression": "partition",
+                                    "generated_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "source_expression": "FROM \"catalog\".\"schema1\".\"customer\" AS \"c\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ],
+                            "downstreams": []
+                        },
+                        {
+                            "name": "\"catalog\".\"schema1\".\"metric_basis\" AS \"mb\"",
+                            "expression": "\"catalog\".\"schema1\".\"metric_basis\" AS \"mb\"",
+                            "generated_expression": null,
+                            "source_expression": null,
+                            "node_type": "Table",
+                            "children": [
+                                {
+                                    "name": "state",
+                                    "expression": "state",
+                                    "generated_expression": "LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                                    "source_expression": "LEFT JOIN \"catalog\".\"schema1\".\"metric_basis\" AS \"mb\" ON \"c\".\"address\" = \"mb\".\"address\"",
+                                    "node_type": "Column",
+                                    "children": [],
+                                    "downstreams": []
+                                }
+                            ],
+                            "downstreams": []
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/lineage/test_cases/test_merge/02_input.sql
+++ b/tests/lineage/test_cases/test_merge/02_input.sql
@@ -1,0 +1,6 @@
+merge into catalog.schema1.customer_metric c
+using catalog.schema1.customer d
+on c.name = d.name
+when matched then update set state = COALESCE(c.state, d.state), phone = d.phone
+when not matched then insert
+values(d.name, d.phone, d.address, 'no state', 'unknown')

--- a/tests/lineage/test_cases/test_merge/02_json_output.json
+++ b/tests/lineage/test_cases/test_merge/02_json_output.json
@@ -1,0 +1,160 @@
+{
+    "name": "myroot",
+    "expression": "ANCHOR",
+    "generated_expression": "MERGE INTO \"catalog\".\"schema1\".\"customer_metric\" AS \"c\" USING \"catalog\".\"schema1\".\"customer\" AS \"d\" ON \"c\".\"name\" = \"d\".\"name\" WHEN MATCHED THEN UPDATE SET \"state\" = COALESCE(\"c\".\"state\", \"d\".\"state\"), \"phone\" = \"d\".\"phone\" WHEN NOT MATCHED THEN INSERT VALUES (\"d\".\"name\", \"d\".\"phone\", \"d\".\"address\", 'no state', 'unknown')",
+    "source_expression": "MERGE INTO \"catalog\".\"schema1\".\"customer_metric\" AS \"c\" USING \"catalog\".\"schema1\".\"customer\" AS \"d\" ON \"c\".\"name\" = \"d\".\"name\" WHEN MATCHED THEN UPDATE SET \"state\" = COALESCE(\"c\".\"state\", \"d\".\"state\"), \"phone\" = \"d\".\"phone\" WHEN NOT MATCHED THEN INSERT VALUES (\"d\".\"name\", \"d\".\"phone\", \"d\".\"address\", 'no state', 'unknown')",
+    "node_type": "Select",
+    "children": [],
+    "downstreams": [
+        {
+            "name": "\"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+            "expression": "\"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+            "generated_expression": null,
+            "source_expression": null,
+            "node_type": "Table",
+            "children": [
+                {
+                    "name": "name",
+                    "expression": "name",
+                    "generated_expression": "SELECT name FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "source_expression": "SELECT name FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "name",
+                            "expression": "name",
+                            "generated_expression": "MERGE INTO \"catalog\".\"schema1\".\"customer_metric\" AS \"c\" USING \"catalog\".\"schema1\".\"customer\" AS \"d\" ON \"c\".\"name\" = \"d\".\"name\" WHEN MATCHED THEN UPDATE SET \"state\" = COALESCE(\"c\".\"state\", \"d\".\"state\"), \"phone\" = \"d\".\"phone\" WHEN NOT MATCHED THEN INSERT VALUES (\"d\".\"name\", \"d\".\"phone\", \"d\".\"address\", 'no state', 'unknown')",
+                            "source_expression": "MERGE INTO \"catalog\".\"schema1\".\"customer_metric\" AS \"c\" USING \"catalog\".\"schema1\".\"customer\" AS \"d\" ON \"c\".\"name\" = \"d\".\"name\" WHEN MATCHED THEN UPDATE SET \"state\" = COALESCE(\"c\".\"state\", \"d\".\"state\"), \"phone\" = \"d\".\"phone\" WHEN NOT MATCHED THEN INSERT VALUES (\"d\".\"name\", \"d\".\"phone\", \"d\".\"address\", 'no state', 'unknown')",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": []
+                        }
+                    ]
+                },
+                {
+                    "name": "phone",
+                    "expression": "phone",
+                    "generated_expression": "SELECT phone FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "source_expression": "SELECT phone FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "phone",
+                            "expression": "phone",
+                            "generated_expression": "MERGE INTO \"catalog\".\"schema1\".\"customer_metric\" AS \"c\" USING \"catalog\".\"schema1\".\"customer\" AS \"d\" ON \"c\".\"name\" = \"d\".\"name\" WHEN MATCHED THEN UPDATE SET \"state\" = COALESCE(\"c\".\"state\", \"d\".\"state\"), \"phone\" = \"d\".\"phone\" WHEN NOT MATCHED THEN INSERT VALUES (\"d\".\"name\", \"d\".\"phone\", \"d\".\"address\", 'no state', 'unknown')",
+                            "source_expression": "MERGE INTO \"catalog\".\"schema1\".\"customer_metric\" AS \"c\" USING \"catalog\".\"schema1\".\"customer\" AS \"d\" ON \"c\".\"name\" = \"d\".\"name\" WHEN MATCHED THEN UPDATE SET \"state\" = COALESCE(\"c\".\"state\", \"d\".\"state\"), \"phone\" = \"d\".\"phone\" WHEN NOT MATCHED THEN INSERT VALUES (\"d\".\"name\", \"d\".\"phone\", \"d\".\"address\", 'no state', 'unknown')",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": []
+                        }
+                    ]
+                },
+                {
+                    "name": "address",
+                    "expression": "address",
+                    "generated_expression": "SELECT address FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "source_expression": "SELECT address FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": [
+                        {
+                            "name": "address",
+                            "expression": "address",
+                            "generated_expression": "MERGE INTO \"catalog\".\"schema1\".\"customer_metric\" AS \"c\" USING \"catalog\".\"schema1\".\"customer\" AS \"d\" ON \"c\".\"name\" = \"d\".\"name\" WHEN MATCHED THEN UPDATE SET \"state\" = COALESCE(\"c\".\"state\", \"d\".\"state\"), \"phone\" = \"d\".\"phone\" WHEN NOT MATCHED THEN INSERT VALUES (\"d\".\"name\", \"d\".\"phone\", \"d\".\"address\", 'no state', 'unknown')",
+                            "source_expression": "MERGE INTO \"catalog\".\"schema1\".\"customer_metric\" AS \"c\" USING \"catalog\".\"schema1\".\"customer\" AS \"d\" ON \"c\".\"name\" = \"d\".\"name\" WHEN MATCHED THEN UPDATE SET \"state\" = COALESCE(\"c\".\"state\", \"d\".\"state\"), \"phone\" = \"d\".\"phone\" WHEN NOT MATCHED THEN INSERT VALUES (\"d\".\"name\", \"d\".\"phone\", \"d\".\"address\", 'no state', 'unknown')",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": []
+                        }
+                    ]
+                },
+                {
+                    "name": "state",
+                    "expression": "state",
+                    "generated_expression": "SELECT state FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "source_expression": "SELECT state FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": []
+                },
+                {
+                    "name": "custom_col",
+                    "expression": "custom_col",
+                    "generated_expression": "SELECT custom_col FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "source_expression": "SELECT custom_col FROM \"catalog\".\"schema1\".\"customer_metric\" AS \"c\"",
+                    "node_type": "Column",
+                    "children": [],
+                    "downstreams": []
+                }
+            ],
+            "downstreams": [
+                {
+                    "name": "\"catalog\".\"schema1\".\"customer\" AS \"d\"",
+                    "expression": "\"catalog\".\"schema1\".\"customer\" AS \"d\"",
+                    "generated_expression": null,
+                    "source_expression": null,
+                    "node_type": "Table",
+                    "children": [
+                        {
+                            "name": "id",
+                            "expression": "id",
+                            "generated_expression": "MERGE INTO \"catalog\".\"schema1\".\"customer_metric\" AS \"c\" USING \"catalog\".\"schema1\".\"customer\" AS \"d\" ON \"c\".\"name\" = \"d\".\"name\" WHEN MATCHED THEN UPDATE SET \"state\" = COALESCE(\"c\".\"state\", \"d\".\"state\"), \"phone\" = \"d\".\"phone\" WHEN NOT MATCHED THEN INSERT VALUES (\"d\".\"name\", \"d\".\"phone\", \"d\".\"address\", 'no state', 'unknown')",
+                            "source_expression": "MERGE INTO \"catalog\".\"schema1\".\"customer_metric\" AS \"c\" USING \"catalog\".\"schema1\".\"customer\" AS \"d\" ON \"c\".\"name\" = \"d\".\"name\" WHEN MATCHED THEN UPDATE SET \"state\" = COALESCE(\"c\".\"state\", \"d\".\"state\"), \"phone\" = \"d\".\"phone\" WHEN NOT MATCHED THEN INSERT VALUES (\"d\".\"name\", \"d\".\"phone\", \"d\".\"address\", 'no state', 'unknown')",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": []
+                        },
+                        {
+                            "name": "name",
+                            "expression": "name",
+                            "generated_expression": "MERGE INTO \"catalog\".\"schema1\".\"customer_metric\" AS \"c\" USING \"catalog\".\"schema1\".\"customer\" AS \"d\" ON \"c\".\"name\" = \"d\".\"name\" WHEN MATCHED THEN UPDATE SET \"state\" = COALESCE(\"c\".\"state\", \"d\".\"state\"), \"phone\" = \"d\".\"phone\" WHEN NOT MATCHED THEN INSERT VALUES (\"d\".\"name\", \"d\".\"phone\", \"d\".\"address\", 'no state', 'unknown')",
+                            "source_expression": "MERGE INTO \"catalog\".\"schema1\".\"customer_metric\" AS \"c\" USING \"catalog\".\"schema1\".\"customer\" AS \"d\" ON \"c\".\"name\" = \"d\".\"name\" WHEN MATCHED THEN UPDATE SET \"state\" = COALESCE(\"c\".\"state\", \"d\".\"state\"), \"phone\" = \"d\".\"phone\" WHEN NOT MATCHED THEN INSERT VALUES (\"d\".\"name\", \"d\".\"phone\", \"d\".\"address\", 'no state', 'unknown')",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": []
+                        },
+                        {
+                            "name": "phone",
+                            "expression": "phone",
+                            "generated_expression": "MERGE INTO \"catalog\".\"schema1\".\"customer_metric\" AS \"c\" USING \"catalog\".\"schema1\".\"customer\" AS \"d\" ON \"c\".\"name\" = \"d\".\"name\" WHEN MATCHED THEN UPDATE SET \"state\" = COALESCE(\"c\".\"state\", \"d\".\"state\"), \"phone\" = \"d\".\"phone\" WHEN NOT MATCHED THEN INSERT VALUES (\"d\".\"name\", \"d\".\"phone\", \"d\".\"address\", 'no state', 'unknown')",
+                            "source_expression": "MERGE INTO \"catalog\".\"schema1\".\"customer_metric\" AS \"c\" USING \"catalog\".\"schema1\".\"customer\" AS \"d\" ON \"c\".\"name\" = \"d\".\"name\" WHEN MATCHED THEN UPDATE SET \"state\" = COALESCE(\"c\".\"state\", \"d\".\"state\"), \"phone\" = \"d\".\"phone\" WHEN NOT MATCHED THEN INSERT VALUES (\"d\".\"name\", \"d\".\"phone\", \"d\".\"address\", 'no state', 'unknown')",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": []
+                        },
+                        {
+                            "name": "address",
+                            "expression": "address",
+                            "generated_expression": "MERGE INTO \"catalog\".\"schema1\".\"customer_metric\" AS \"c\" USING \"catalog\".\"schema1\".\"customer\" AS \"d\" ON \"c\".\"name\" = \"d\".\"name\" WHEN MATCHED THEN UPDATE SET \"state\" = COALESCE(\"c\".\"state\", \"d\".\"state\"), \"phone\" = \"d\".\"phone\" WHEN NOT MATCHED THEN INSERT VALUES (\"d\".\"name\", \"d\".\"phone\", \"d\".\"address\", 'no state', 'unknown')",
+                            "source_expression": "MERGE INTO \"catalog\".\"schema1\".\"customer_metric\" AS \"c\" USING \"catalog\".\"schema1\".\"customer\" AS \"d\" ON \"c\".\"name\" = \"d\".\"name\" WHEN MATCHED THEN UPDATE SET \"state\" = COALESCE(\"c\".\"state\", \"d\".\"state\"), \"phone\" = \"d\".\"phone\" WHEN NOT MATCHED THEN INSERT VALUES (\"d\".\"name\", \"d\".\"phone\", \"d\".\"address\", 'no state', 'unknown')",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": []
+                        },
+                        {
+                            "name": "location",
+                            "expression": "location",
+                            "generated_expression": "MERGE INTO \"catalog\".\"schema1\".\"customer_metric\" AS \"c\" USING \"catalog\".\"schema1\".\"customer\" AS \"d\" ON \"c\".\"name\" = \"d\".\"name\" WHEN MATCHED THEN UPDATE SET \"state\" = COALESCE(\"c\".\"state\", \"d\".\"state\"), \"phone\" = \"d\".\"phone\" WHEN NOT MATCHED THEN INSERT VALUES (\"d\".\"name\", \"d\".\"phone\", \"d\".\"address\", 'no state', 'unknown')",
+                            "source_expression": "MERGE INTO \"catalog\".\"schema1\".\"customer_metric\" AS \"c\" USING \"catalog\".\"schema1\".\"customer\" AS \"d\" ON \"c\".\"name\" = \"d\".\"name\" WHEN MATCHED THEN UPDATE SET \"state\" = COALESCE(\"c\".\"state\", \"d\".\"state\"), \"phone\" = \"d\".\"phone\" WHEN NOT MATCHED THEN INSERT VALUES (\"d\".\"name\", \"d\".\"phone\", \"d\".\"address\", 'no state', 'unknown')",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": []
+                        },
+                        {
+                            "name": "partition",
+                            "expression": "partition",
+                            "generated_expression": "MERGE INTO \"catalog\".\"schema1\".\"customer_metric\" AS \"c\" USING \"catalog\".\"schema1\".\"customer\" AS \"d\" ON \"c\".\"name\" = \"d\".\"name\" WHEN MATCHED THEN UPDATE SET \"state\" = COALESCE(\"c\".\"state\", \"d\".\"state\"), \"phone\" = \"d\".\"phone\" WHEN NOT MATCHED THEN INSERT VALUES (\"d\".\"name\", \"d\".\"phone\", \"d\".\"address\", 'no state', 'unknown')",
+                            "source_expression": "MERGE INTO \"catalog\".\"schema1\".\"customer_metric\" AS \"c\" USING \"catalog\".\"schema1\".\"customer\" AS \"d\" ON \"c\".\"name\" = \"d\".\"name\" WHEN MATCHED THEN UPDATE SET \"state\" = COALESCE(\"c\".\"state\", \"d\".\"state\"), \"phone\" = \"d\".\"phone\" WHEN NOT MATCHED THEN INSERT VALUES (\"d\".\"name\", \"d\".\"phone\", \"d\".\"address\", 'no state', 'unknown')",
+                            "node_type": "Column",
+                            "children": [],
+                            "downstreams": []
+                        }
+                    ],
+                    "downstreams": []
+                }
+            ]
+        }
+    ]
+}

--- a/tests/lineage/test_cases/test_merge/schema.json
+++ b/tests/lineage/test_cases/test_merge/schema.json
@@ -1,0 +1,29 @@
+{
+  "catalog": {
+      "schema1": {
+          "customer": {
+              "id": "INTEGER",
+              "name": "STRING",
+              "phone": "STRING",
+              "address": "STRING",
+              "location": "STRING",
+              "partition": "INTEGER"
+          },
+          "latest_customer": {
+            "new_id": "INTEGER",
+            "name": "STRING",
+            "latest_phone": "STRING",
+            "address": "STRING",
+            "partition": "INTEGER",
+            "location": "STRING"
+          },
+          "customer_metric": {
+              "name": "STRING",
+              "phone": "STRING",
+              "address": "STRING",
+              "state": "STRING",
+              "custom_col": "STRING"
+          }
+      }
+  }
+}

--- a/tests/lineage/test_lineage.py
+++ b/tests/lineage/test_lineage.py
@@ -46,8 +46,10 @@ class TestLineage(unittest.TestCase):
 
             self.configurations = list(map(ConfigurationModel.model_validate, conf))
 
-    def validate_lineage_equal(self, sql: str, dialect: str, schema: dict, output_str: str):
-        with self.subTest("Test lineage equal: {}: {} == {}".format(dialect, sql, output_str)):
+    def validate_lineage_equal(
+        self, test_name: str, sql: str, dialect: str, schema: dict, output_str: str
+    ):
+        with self.subTest("Test lineage equal: {}".format(test_name)):
             generated_lineage = lineage(sql, dialect, schema)
             self.assertEqual(json.dumps(generated_lineage.to_json_dict(), indent=4), output_str)
 
@@ -67,7 +69,11 @@ class TestLineage(unittest.TestCase):
             schema = json.loads(safe_read(path / conf.schema_path))
 
             self.validate_lineage_equal(
-                sql=input_str, dialect=conf.dialect, schema=schema, output_str=output_str
+                test_name=f"{ pathlib.Path(conf.path) / conf.input_path} -> {pathlib.Path(conf.path) /conf.output_path}",
+                sql=input_str,
+                dialect=conf.dialect,
+                schema=schema,
+                output_str=output_str,
             )
 
 


### PR DESCRIPTION
Fixes #25 

This pull request add support for merge statement, including all standard merge syntax (plus when not matched by source).

Data lineage is linked between merge source (table or subquery) and merge target table, using `merge_update` and `merge_insert` in the `when_clause`.

Initiative:

- [x] Implement `get_scope` to dynamic create any valid scope (Scope or Table).
- [x] Implement `qualify_ast` to perform extended qualify operation.
- [ ] Support qualify merge statement with `WHEN NOT MATCHED THEN INSERT ROW` in bigquery dialect.
- [x] Support subquery scope.
- [x] Link any source columns to dest columns (and can easily infer the columns if schema is not available).
- [x] Lineage unit testing for merge statement.


## Examples:
schema:
```json
{
  "catalog": {
      "schema1": {
          "customer": {
              "id": "INTEGER",
              "name": "STRING",
              "phone": "STRING",
              "address": "STRING",
              "location": "STRING",
              "partition": "INTEGER"
          },
          "latest_customer": {
            "new_id": "INTEGER",
            "name": "STRING",
            "latest_phone": "STRING",
            "address": "STRING",
            "partition": "INTEGER",
            "location": "STRING"
          },
          "customer_metric": {
              "name": "STRING",
              "phone": "STRING",
              "address": "STRING",
              "state": "STRING",
              "custom_col": "STRING"
          }
      }
  }
}
```

---
1.
SQL: 
```sql
merge into catalog.schema1.customer_metric c
using catalog.schema1.customer d
on c.name = d.name
when matched then update set state = COALESCE(c.state, d.state), phone = d.phone
when not matched then insert
values(d.name, d.phone, d.address, 'no state', 'unknown')
```

Lineage:
```mermaid
%%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%
graph LR
subgraph 4402094096 ["Table: catalog.schema1.customer AS d"]
4402096784["id"]
4402097104["name"]
4402119184["phone"]
4402164816["address"]
4402248528["location"]
4402166096["partition"]
end

subgraph 4402094416 ["Table: catalog.schema1.customer_metric AS c"]
4402266640["name"]
4402277520["phone"]
4401064784["address"]
4402266768["state"]
4402324112["custom_col"]
end
4402097104 --> 4402266640
4402119184 --> 4402277520
4402164816 --> 4401064784
```

2.
SQL: 
```sql
merge into catalog.schema1.customer_metric c
using (
select c.name, c.phone, null as address, coalesce(mb.state, 'default') as state
from catalog.schema1.customer c 
left join catalog.schema1.metric_basis mb on c.address = mb.address
) d
on c.name = d.name
when matched then update set state = COALESCE(c.state, d.state), phone = d.phone
when not matched by source then update set address = COALESCE(c.address, 'default')
when not matched then insert
values(d.name, d.phone, d.address, d.state, 'unknown')
```

Lineage:
```mermaid
%%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%
graph LR
subgraph 4354588304 ["Table: catalog.schema1.customer AS c"]
4354582160["id"]
4354579472["name"]
4354580176["phone"]
4354580816["address"]
4354606800["location"]
4354587216["partition"]
end

subgraph 4354616400 ["Table: catalog.schema1.metric_basis AS mb"]
4354464720["state"]
end

subgraph 4354588496 ["Subquery: d"]
4354645456["name"]
4354643408["phone"]
4354463440["address"]
4354463184["state"]
end
4354579472 --> 4354645456
4354580176 --> 4354643408
4354463184_exp[["COALESCE(mb.state, 'default')"]] ----- 4354463184
4354464720 --> 4354463184

subgraph 4354587664 ["Table: catalog.schema1.customer_metric AS c"]
4354610896["name"]
4354612752["phone"]
4354579536["address"]
4354615824["state"]
4354633680["custom_col"]
end
4354645456 --> 4354610896
4354643408 --> 4354612752
4354463440 --> 4354579536
4354463184 --> 4354615824
```

